### PR TITLE
[feat] Toast 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.10",
         "@tanstack/react-query": "^5.81.2",
         "axios": "^1.10.0",
+        "clsx": "^2.1.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
@@ -2651,6 +2652,15 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
+        "tailwind-variants": "^1.0.0",
         "tailwindcss": "^4.1.10",
         "vite-plugin-svgr": "^4.3.0"
       },
@@ -6001,6 +6002,32 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.0.2.tgz",
+      "integrity": "sha512-l7z+OYZ7mu3DTqrL88RiKrKIqO3NcpEO8V/Od04bNpvk0kiIFndGEoqfuzvj4yuhRkHKjRkII2z+KS2HfPcSxw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwind-variants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tailwind-variants/-/tailwind-variants-1.0.0.tgz",
+      "integrity": "sha512-2WSbv4ulEEyuBKomOunut65D8UZwxrHoRfYnxGcQNnHqlSCp2+B7Yz2W+yrNDrxRodOXtGD/1oCcKGNBnUqMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "tailwind-merge": "3.0.2"
+      },
+      "engines": {
+        "node": ">=16.x",
+        "pnpm": ">=7.x"
+      },
+      "peerDependencies": {
+        "tailwindcss": "*"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
+    "tailwind-variants": "^1.0.0",
     "tailwindcss": "^4.1.10",
     "vite-plugin-svgr": "^4.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@tailwindcss/vite": "^4.1.10",
     "@tanstack/react-query": "^5.81.2",
     "axios": "^1.10.0",
+    "clsx": "^2.1.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
+import ToastExample from './example/ToastExample';
+
 function App() {
-  return <div className='text-3xl font-bold underline bg-blue-300'>Hi</div>;
+  return <ToastExample />;
 }
 
 export default App;

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,28 +1,36 @@
 import React from 'react';
-import clsx from 'clsx';
+import { tv } from 'tailwind-variants';
 
-type ToastProps = {
+export interface ToastProps {
   show: boolean;
   message: string;
-  type?: string;
-};
+  type?: 'positive' | 'error';
+}
+
+const toast = tv({
+  base: [
+    'fixed top-[80px] left-1/2 -translate-x-1/2 w-60 h-10 rounded-3xl bg-white',
+    'flex items-center justify-center shadow-md',
+    'text-base font-normal transition-opacity duration-300',
+  ],
+  variants: {
+    type: {
+      positive: 'text-green-500 border border-green-500',
+      error: 'text-red-500 border border-red-500',
+    },
+    show: {
+      true: 'opacity-100',
+      false: 'opacity-0',
+    },
+  },
+  defaultVariants: {
+    type: 'positive',
+    show: false,
+  },
+});
 
 const Toast: React.FC<ToastProps> = ({ show, message, type }) => {
-  return (
-    <div
-      className={clsx(
-        'fixed top-[80px] left-1/2 -translate-x-1/2 w-60 h-10 rounded-3xl bg-white',
-        'flex items-center justify-center shadow-md text-base font-normal',
-        type === 'positive'
-          ? 'text-green-500 border border-green-500'
-          : 'text-red-500 border border-red-500',
-        'transition-opacity duration-300',
-        show ? 'opacity-100' : 'opacity-0',
-      )}
-    >
-      {message}
-    </div>
-  );
+  return <div className={toast({ type, show })}>{message}</div>;
 };
 
 export default Toast;

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import { tv } from 'tailwind-variants';
 
+// props 타입 정의
 export interface ToastProps {
   show: boolean;
   message: string;
   type?: 'positive' | 'error';
 }
 
+// tailwind-variants를 사용하여 toast 스타일을 구성
 const toast = tv({
+  // 기본 스타일 (항상 적용)
   base: [
     'fixed top-[80px] left-1/2 -translate-x-1/2 w-60 h-10 rounded-3xl bg-white',
     'flex items-center justify-center shadow-md',
     'text-base font-normal transition-opacity duration-300',
   ],
+  // 조건부 스타일 정의
   variants: {
     type: {
       positive: 'text-green-500 border border-green-500',
@@ -23,6 +27,7 @@ const toast = tv({
       false: 'opacity-0',
     },
   },
+  // 기본 variant 설정
   defaultVariants: {
     type: 'positive',
     show: false,

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,5 +1,28 @@
-const Toast = () => {
-  return <div></div>;
+import React from 'react';
+import clsx from 'clsx';
+
+type ToastProps = {
+  show: boolean;
+  message: string;
+  type?: string;
+};
+
+const Toast: React.FC<ToastProps> = ({ show, message, type }) => {
+  return (
+    <div
+      className={clsx(
+        'fixed top-[80px] left-1/2 -translate-x-1/2 w-60 h-10 rounded-3xl bg-white',
+        'flex items-center justify-center shadow-md text-base font-normal',
+        type === 'positive'
+          ? 'text-green-500 border border-green-500'
+          : 'text-red-500 border border-red-500',
+        'transition-opacity duration-300',
+        show ? 'opacity-100' : 'opacity-0',
+      )}
+    >
+      {message}
+    </div>
+  );
 };
 
 export default Toast;

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -14,7 +14,7 @@ const toast = tv({
   base: [
     'fixed top-[80px] left-1/2 -translate-x-1/2 w-60 h-10 rounded-3xl bg-white',
     'flex items-center justify-center shadow-md',
-    'text-base font-normal transition-opacity duration-300',
+    'text-base font-normal transition-opacity duration-500',
   ],
   // 조건부 스타일 정의
   variants: {

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -13,7 +13,7 @@ const toast = tv({
   // 기본 스타일 (항상 적용)
   base: [
     'fixed top-[80px] left-1/2 -translate-x-1/2 w-60 h-10 rounded-3xl bg-white',
-    'flex items-center justify-center shadow-md',
+    'flex items-center justify-center',
     'text-base font-normal transition-opacity duration-500',
   ],
   // 조건부 스타일 정의

--- a/src/example/ToastExample.tsx
+++ b/src/example/ToastExample.tsx
@@ -1,30 +1,45 @@
-import Toast, { type ToastProps } from '@/components/common/Toast';
-import { useCallback, useState } from 'react';
+import Toast from '@/components/common/Toast';
+import { useState } from 'react';
+
+// ToastItem 타입 정의
+interface ToastItem {
+  id: string;
+  type: 'positive' | 'error';
+  message: string;
+}
 
 const ToastExample = () => {
-  const [toast, setToast] = useState<ToastProps>({ show: false, type: 'error', message: '' });
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
 
-  /* 
-    타입과 메시지를 받아서 상태를 변경하는 함수
-    useCallback을 사용해서 showToast함수가 리렌더링 될 때마다 참조가 바뀌는 것을 방지
-  */
-  const showToast = useCallback((type: 'positive' | 'error', message: string) => {
-    setToast({ show: true, type, message });
+  const showToast = (type: 'positive' | 'error', message: string) => {
+    // 고유한 ID를 생성하여 새로운 Toast 객체를 만듬
+    const newToast = {
+      id: Date.now().toString(),
+      type,
+      message,
+    };
+    setToasts((prev) => [...prev, newToast]); // 현재 toasts 배열에 새로운 Toast를 추가
+
+    // 2초 뒤에 해당 Toast를 배열에서 제거하여 화면에서 사라지게 함
     setTimeout(() => {
-      setToast((prev: any) => ({ ...prev, show: false })); // 2초 뒤에 show: false로 바꿔 토스트 숨기기
+      setToasts((prev) => prev.filter((toast) => toast.id !== newToast.id)); // ID가 일치하지 않는 항목만 남김
     }, 2000);
-  }, []);
+  };
 
   return (
     <>
-      <button className='bg-green-100' onClick={() => showToast('positive', '성공했습니다!')}>
+      <button className='bg-green-100 p-4' onClick={() => showToast('positive', '성공했습니다!')}>
         성공
       </button>
-      <button className='bg-red-100' onClick={() => showToast('error', '실패했습니다.')}>
+      <button className='bg-red-100 p-4' onClick={() => showToast('error', '실패했습니다.')}>
         실패
       </button>
+
+      {/* Toast 리스트 출력 */}
       <div className='p-4'>
-        <Toast show={toast.show} message={toast.message} type={toast.type} />
+        {toasts.map((toast) => (
+          <Toast key={toast.id} show={true} message={toast.message} type={toast.type} />
+        ))}
       </div>
     </>
   );

--- a/src/example/ToastExample.tsx
+++ b/src/example/ToastExample.tsx
@@ -1,0 +1,32 @@
+import Toast from '@/components/common/Toast';
+import { useCallback, useState } from 'react';
+
+const Example = () => {
+  const [toast, setToast] = useState({ show: false, type: 'error', message: '' });
+
+  const showToast = useCallback((type: any, message: string) => {
+    setToast({ show: true, type, message });
+    setTimeout(() => {
+      setToast((prev: any) => ({ ...prev, show: false }));
+    }, 2000);
+  }, []);
+
+  return (
+    <>
+      <button
+        className='bg-green-100 px-4 py-2'
+        onClick={() => showToast('positive', '성공했습니다!')}
+      >
+        성공
+      </button>
+      <button className='bg-red-100 px-4 py-2' onClick={() => showToast('error', '실패했습니다.')}>
+        실패
+      </button>
+      <div className='p-4'>
+        <Toast show={toast.show} message={toast.message} type={toast.type} />
+      </div>
+    </>
+  );
+};
+
+export default Example;

--- a/src/example/ToastExample.tsx
+++ b/src/example/ToastExample.tsx
@@ -1,10 +1,10 @@
-import Toast from '@/components/common/Toast';
+import Toast, { type ToastProps } from '@/components/common/Toast';
 import { useCallback, useState } from 'react';
 
-const Example = () => {
-  const [toast, setToast] = useState({ show: false, type: 'error', message: '' });
+const ToastExample = () => {
+  const [toast, setToast] = useState<ToastProps>({ show: false, type: 'error', message: '' });
 
-  const showToast = useCallback((type: any, message: string) => {
+  const showToast = useCallback((type: 'positive' | 'error', message: string) => {
     setToast({ show: true, type, message });
     setTimeout(() => {
       setToast((prev: any) => ({ ...prev, show: false }));
@@ -13,13 +13,10 @@ const Example = () => {
 
   return (
     <>
-      <button
-        className='bg-green-100 px-4 py-2'
-        onClick={() => showToast('positive', '성공했습니다!')}
-      >
+      <button className='bg-green-100' onClick={() => showToast('positive', '성공했습니다!')}>
         성공
       </button>
-      <button className='bg-red-100 px-4 py-2' onClick={() => showToast('error', '실패했습니다.')}>
+      <button className='bg-red-100' onClick={() => showToast('error', '실패했습니다.')}>
         실패
       </button>
       <div className='p-4'>
@@ -29,4 +26,4 @@ const Example = () => {
   );
 };
 
-export default Example;
+export default ToastExample;

--- a/src/example/ToastExample.tsx
+++ b/src/example/ToastExample.tsx
@@ -4,10 +4,14 @@ import { useCallback, useState } from 'react';
 const ToastExample = () => {
   const [toast, setToast] = useState<ToastProps>({ show: false, type: 'error', message: '' });
 
+  /* 
+    타입과 메시지를 받아서 상태를 변경하는 함수
+    useCallback을 사용해서 showToast함수가 리렌더링 될 때마다 참조가 바뀌는 것을 방지
+  */
   const showToast = useCallback((type: 'positive' | 'error', message: string) => {
     setToast({ show: true, type, message });
     setTimeout(() => {
-      setToast((prev: any) => ({ ...prev, show: false }));
+      setToast((prev: any) => ({ ...prev, show: false })); // 2초 뒤에 show: false로 바꿔 토스트 숨기기
     }, 2000);
   }, []);
 


### PR DESCRIPTION
## 📂 관련 이슈

- closes #5

<br>

## 🔀 PR 개요

- Toast 컴포넌트 구현

<br>

## 📝 작업 내용

- 처음에 clsx 라이브러리를 활용해서 구현했다가 tailwind-variants 라이브러리를 활용해서 type에 따라 바뀔 수 있도록 구현
- 예시 컴포넌트로 ToastExample를 만들어 버튼을 눌러서 어떻게 작동하는지 보여줄 수 있게 함

<br>

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/e888303b-3811-40fe-be80-b43a6d3860d0)

![image](https://github.com/user-attachments/assets/8ddef917-f188-4bbf-ab20-2b98d59042f7)

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>

## 🔧 추가 사항

> 아직 완료 못한 작업, 리뷰어가 알면 좋은 내용, 향후 개선 아이디어 등

<br>
