### PR TITLE
[Feat] #27 검색 결과 창 Card 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@typescript-eslint/eslint-plugin": "^8.35.0",
@@ -1664,6 +1665,16 @@
       },
       "peerDependencies": {
         "@svgr/core": "*"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@tailwindcss/node": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@typescript-eslint/eslint-plugin": "^8.35.0",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
-import { Home, Search, Save, Example } from '@/pages';
+import { Home, Search, Save, Example, SearchResult } from '@/pages';
 import App from '@/App';
 
 const router = createBrowserRouter([
@@ -20,6 +20,10 @@ const router = createBrowserRouter([
       {
         path: 'search',
         element: <Search />,
+      },
+      {
+        path: 'search-result',
+        element: <SearchResult />,
       },
       {
         path: 'example',

--- a/src/atoms.ts
+++ b/src/atoms.ts
@@ -5,15 +5,7 @@ import {
   dummyTagList,
   dummyTimeOptions,
 } from './contants/DummyData';
-
-export interface ChipProps {
-  id: number;
-  content: string;
-  isSelected: boolean;
-  type: 'category' | 'tag' | 'suggestion';
-  deleteable?: boolean;
-  isNew?: boolean;
-}
+import type { ChipProps } from './types';
 
 // Save Page Atoms
 const linkAtom = atom('');

--- a/src/components/ui/card/CompactCard.tsx
+++ b/src/components/ui/card/CompactCard.tsx
@@ -1,0 +1,34 @@
+import Image from '@/components/common/Image';
+import React, { useRef, useEffect, useState } from 'react';
+
+const CompactCard = () => {
+  return (
+    <div className='w-1/2 lg:w-1/3 xl:w-1/4 border border-gray-200 shadow-md rounded-lg p-4 flex items-center flex-row gap-4'>
+      <Image
+        src={'https://cdn.pixabay.com/photo/2021/03/18/19/56/keyboard-6105750_960_720.jpg'}
+        alt='CompactCard'
+        className='w-[5.5rem] h-[5.5rem] rounded-lg'
+      />
+      <div className='flex flex-col gap-2'>
+        <p className='text-base font-semibold'>SEMIHARU CITY POP</p>
+        <p className='text-sm text-grayText line-clamp-4'>
+          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
+          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
+          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
+          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
+          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
+        </p>
+        <div className='flex flex-row gap-2'>
+          <p className='text-sm text-grayText'>카테고리</p>
+          <div className='flex flex-row gap-2'>
+            <p className='text-sm text-grayText'>테그</p>
+            <p className='text-sm text-grayText'>테그</p>
+            <p className='text-sm text-grayText'>테그</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CompactCard;

--- a/src/components/ui/card/CompactCard.tsx
+++ b/src/components/ui/card/CompactCard.tsx
@@ -1,29 +1,37 @@
 import Image from '@/components/common/Image';
-import React, { useRef, useEffect, useState } from 'react';
+import clsx from 'clsx';
 
 const CompactCard = () => {
   return (
-    <div className='w-1/2 lg:w-1/3 xl:w-1/4 border border-gray-200 shadow-md rounded-lg p-4 flex items-center flex-row gap-4'>
+    <div className='w-full border border-gray-200 shadow-md rounded-lg p-2 flex items-stretch flex-row gap-4'>
       <Image
         src={'https://cdn.pixabay.com/photo/2021/03/18/19/56/keyboard-6105750_960_720.jpg'}
         alt='CompactCard'
-        className='w-[5.5rem] h-[5.5rem] rounded-lg'
+        className={clsx('aspect-square rounded-lg object-cover', 'h-26', 'sm:h-26', 'md:h-30')}
       />
-      <div className='flex flex-col gap-2'>
+      <div className='flex flex-col gap-2 justify-between'>
         <p className='text-base font-semibold'>SEMIHARU CITY POP</p>
-        <p className='text-sm text-grayText line-clamp-4'>
+        <p
+          className={clsx(
+            'text-sm text-grayText line-clamp-2',
+            'sm:line-clamp-2',
+            'md:line-clamp-3',
+          )}
+        >
           작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
           작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
           작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
           작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
           작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
         </p>
-        <div className='flex flex-row gap-2'>
-          <p className='text-sm text-grayText'>카테고리</p>
+        <div className='flex flex-row items-center gap-2'>
+          <p className='text-sm text-darkGray bg-snowGray rounded-lg px-2 py-1 font-medium'>
+            카테고리
+          </p>
           <div className='flex flex-row gap-2'>
-            <p className='text-sm text-grayText'>테그</p>
-            <p className='text-sm text-grayText'>테그</p>
-            <p className='text-sm text-grayText'>테그</p>
+            <p className='text-sm text-grayText font-medium'>태그</p>
+            <p className='text-sm text-grayText font-medium'>태그</p>
+            <p className='text-sm text-grayText font-medium'>태그</p>
           </div>
         </div>
       </div>

--- a/src/components/ui/card/CompactCard.tsx
+++ b/src/components/ui/card/CompactCard.tsx
@@ -1,16 +1,17 @@
 import Image from '@/components/common/Image';
+import type { CompactCardProps } from '@/types';
 import clsx from 'clsx';
 
-const CompactCard = () => {
+const CompactCard = ({ title, src, memo, category, tags }: CompactCardProps) => {
   return (
     <div className='w-full border border-gray-200 shadow-md rounded-lg p-2 flex items-stretch flex-row gap-4'>
       <Image
-        src={'https://cdn.pixabay.com/photo/2021/03/18/19/56/keyboard-6105750_960_720.jpg'}
+        src={src}
         alt='CompactCard'
         className={clsx('aspect-square rounded-lg object-cover', 'h-26', 'sm:h-26', 'md:h-30')}
       />
       <div className='flex flex-col gap-2 justify-between'>
-        <p className='text-base font-semibold'>SEMIHARU CITY POP</p>
+        <p className='text-base font-semibold'>{title}</p>
         <p
           className={clsx(
             'text-sm text-grayText line-clamp-2',
@@ -18,20 +19,18 @@ const CompactCard = () => {
             'md:line-clamp-3',
           )}
         >
-          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
-          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
-          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
-          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
-          작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질.
+          {memo}
         </p>
         <div className='flex flex-row items-center gap-2'>
           <p className='text-sm text-darkGray bg-snowGray rounded-lg px-2 py-1 font-medium'>
-            카테고리
+            {category}
           </p>
           <div className='flex flex-row gap-2'>
-            <p className='text-sm text-grayText font-medium'>태그</p>
-            <p className='text-sm text-grayText font-medium'>태그</p>
-            <p className='text-sm text-grayText font-medium'>태그</p>
+            {tags.map((tag, index) => (
+              <p key={index} className='text-sm text-grayText font-medium'>
+                {tag}
+              </p>
+            ))}
           </div>
         </div>
       </div>

--- a/src/contants/DummyData.tsx
+++ b/src/contants/DummyData.tsx
@@ -1,5 +1,5 @@
 // 더미 데이터(카테고리, 태그)
-import type { ChipProps } from '@/atoms';
+import type { ChipProps, CompactCardProps } from '@/types';
 
 const dummyCategoryList: ChipProps[] = [
   { id: 0, content: '카테고리', isSelected: false, type: 'category' },
@@ -21,6 +21,37 @@ const dummyTagList: ChipProps[] = [
   { id: 2, content: '태그', isSelected: false, type: 'tag', isNew: false },
   { id: 3, content: '태그', isSelected: false, type: 'tag', isNew: false },
   { id: 4, content: '태그', isSelected: false, type: 'tag', isNew: false },
+];
+
+const dummyCompactCardList: CompactCardProps[] = [
+  {
+    title: 'SEMIHARU CITY PO',
+    src: 'https://cdn.pixabay.com/photo/2021/03/18/19/56/keyboard-6105750_960_720.jpg',
+    memo: '작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트.',
+    category: '카테고리',
+    tags: ['태그', '태그', '태그'],
+  },
+  {
+    title: 'SEMIHARU CITY PO',
+    src: 'https://cdn.pixabay.com/photo/2021/03/18/19/56/keyboard-6105750_960_720.jpg',
+    memo: '작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트.',
+    category: '카테고리',
+    tags: ['태그', '태그', '태그'],
+  },
+  {
+    title: 'SEMIHARU CITY PO',
+    src: 'https://cdn.pixabay.com/photo/2021/03/18/19/56/keyboard-6105750_960_720.jpg',
+    memo: '작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트.',
+    category: '카테고리',
+    tags: ['태그', '태그', '태그'],
+  },
+  {
+    title: 'SEMIHARU CITY PO',
+    src: 'https://cdn.pixabay.com/photo/2021/03/18/19/56/keyboard-6105750_960_720.jpg',
+    memo: '작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트. 친구에게 추천받음. 내가 딱 좋아하는 시티팝 재질. 작업하면서 듣기 좋은 플레이리스트.',
+    category: '카테고리',
+    tags: ['태그', '태그', '태그'],
+  },
 ];
 
 // 더미 데이터(알림 설정 시간)
@@ -78,4 +109,10 @@ const dummyTimeOptions = [
   },
 ];
 
-export { dummyCategoryList, dummyTagList, dummyDateOptions, dummyTimeOptions };
+export {
+  dummyCategoryList,
+  dummyTagList,
+  dummyCompactCardList,
+  dummyDateOptions,
+  dummyTimeOptions,
+};

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -1,11 +1,13 @@
 import CompactCard from '@/components/ui/card/CompactCard';
+import { dummyCompactCardList } from '@/contants/DummyData';
+import type { CompactCardProps } from '@/types';
 
 const SearchResult = () => {
   return (
     <div className='flex flex-col gap-4 w-full p-4'>
-      <CompactCard />
-      <CompactCard />
-      <CompactCard />
+      {dummyCompactCardList.map((card: CompactCardProps) => (
+        <CompactCard key={card.title} {...card} />
+      ))}
     </div>
   );
 };

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -2,7 +2,9 @@ import CompactCard from '@/components/ui/card/CompactCard';
 
 const SearchResult = () => {
   return (
-    <div>
+    <div className='flex flex-col gap-4 w-full p-4'>
+      <CompactCard />
+      <CompactCard />
       <CompactCard />
     </div>
   );

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -5,8 +5,8 @@ import type { CompactCardProps } from '@/types';
 const SearchResult = () => {
   return (
     <div className='flex flex-col gap-4 w-full p-4'>
-      {dummyCompactCardList.map((card: CompactCardProps) => (
-        <CompactCard key={card.title} {...card} />
+      {dummyCompactCardList.map((card: CompactCardProps, index: number) => (
+        <CompactCard key={index} {...card} />
       ))}
     </div>
   );

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -1,0 +1,11 @@
+import CompactCard from '@/components/ui/card/CompactCard';
+
+const SearchResult = () => {
+  return (
+    <div>
+      <CompactCard />
+    </div>
+  );
+};
+
+export default SearchResult;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,5 +2,6 @@ import Home from './Home';
 import Save from './save/Save';
 import Search from './Search';
 import Example from './Example';
+import SearchResult from './SearchResult';
 
-export { Home, Save, Search, Example };
+export { Home, Save, Search, Example, SearchResult };

--- a/src/pages/save/CategoryTagSelector.tsx
+++ b/src/pages/save/CategoryTagSelector.tsx
@@ -5,6 +5,7 @@ import Chip from '@/components/common/Chip';
 import { useEffect, useState } from 'react';
 import Modal from '@/components/common/Modal';
 import TextField from '@/components/ui/TextField';
+import type { ChipProps } from '@/types';
 import {
   categoryListAtom,
   isSaveButtonDisabledAtom,
@@ -16,7 +17,6 @@ import {
   visibleCategoryAtom,
   visibleMemoAndAlarmAtom,
   visibleTagAtom,
-  type ChipProps,
 } from '@/atoms';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 

--- a/src/pages/save/Save.tsx
+++ b/src/pages/save/Save.tsx
@@ -40,14 +40,6 @@ const SaveButton = tv({
   },
 });
 
-export interface ChipProps {
-  id: number;
-  content: string;
-  isSelected: boolean;
-  type: 'category' | 'tag' | 'suggestion';
-  deleteable?: boolean;
-}
-
 const Save = () => {
   const navigate = useNavigate();
   const isSaveButtonDisabled = useAtomValue(isSaveButtonDisabledAtom);

--- a/src/style.css
+++ b/src/style.css
@@ -9,6 +9,7 @@
   --color-lightGray: #f5f7f7;
   --color-lightBlueGray: #d8dce6;
   --color-veryLightGray: #eeeeee;
+  --color-snowGray: #f2f3f7;
   --color-darkGray: #090e1d;
   --color-grayBg: #f2f3f7;
   --color-primary: #397fff;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+export interface ChipProps {
+  id: number;
+  content: string;
+  isSelected: boolean;
+  type: 'category' | 'tag' | 'suggestion';
+  deleteable?: boolean;
+  isNew?: boolean;
+}
+
+export interface CompactCardProps {
+  title: string;
+  src: string;
+  memo: string;
+  category: string;
+  tags: string[];
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,6 @@
+// tailwind.config.js
+module.exports = {
+  plugins: [
+    require('@tailwindcss/line-clamp'),
+  ],
+};


### PR DESCRIPTION
## 📂 관련 이슈

- closes #27 

<br>

## 🔀 PR 개요

> 검색 완료 페이지에서 사용되는 Compact Card 컴포넌트 구현

<br>

## 📝 작업 내용

- tailwindcss/line-clamp 라이브러리 설치
- CompactCard 다자인 구현
- CompactCard 컴포넌트 모듈화
- Types 파일 구조화

<br>

## 📸 스크린샷
- PC ( Memo가 3줄까지 보임)
<img width="843" height="647" alt="image" src="https://github.com/user-attachments/assets/ea0a4f58-3fbd-405a-a223-b4060e2c6f41" />

- 모바일 ( Memo가 2줄까지 보임)
<img width="317" height="614" alt="image" src="https://github.com/user-attachments/assets/c4ca71f3-f069-46d4-8c5a-be4aaae4d416" />

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>
