### PR TITLE
[Fix] #30 홈 검색 창 처리 방법 변경

### DIFF
--- a/src/components/layout/footer/HomeFooter.tsx
+++ b/src/components/layout/footer/HomeFooter.tsx
@@ -11,7 +11,7 @@ const HomeFooter = () => {
       icon={<AddIcon width={30} height={30} fill='#FFFFFF' className='text-white z-50' />}
       className={clsx(
         'bg-blue flex fixed right-5 bottom-5 justify-center items-center w-15 h-15',
-        'rounded-4xl hover:brightness-80 transition',
+        'rounded-4xl hover:brightness-80 transition z-20',
       )}
     ></Button>
   );

--- a/src/components/layout/searchBar/ChangeSearchBar.tsx
+++ b/src/components/layout/searchBar/ChangeSearchBar.tsx
@@ -1,0 +1,63 @@
+// ChangeSearchBar.tsx
+import { useRef, useState, useEffect } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { isMobile } from 'react-device-detect';
+import clsx from 'clsx';
+import HomeSearchBar from './HomeSearchBar';
+
+// props로 검색창의 top마진 값 전달 받음
+interface ChangeSearchBarProps {
+  barMarginTop: number;
+}
+
+const ChangeSearchBar = ({ barMarginTop }: ChangeSearchBarProps) => {
+  const searchBarRef = useRef<HTMLDivElement>(null);
+  const [isFixedBar, setISFixedBar] = useState(false);
+  const [isBlur, setIsBlur] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (!searchBarRef.current) return; // 아직 검색창이 렌더링 되지 않았으면 종료
+
+      //검색창 DOM 요소의 위치 정보를 가져옴 (브라우저 뷰포트 기준)
+      // -> getBoundingClientRect()는 브라우저에서 뷰포트(화면) 내 위치를 알려주는 메서드
+      const barPosition = searchBarRef.current.getBoundingClientRect();
+      const isPassedMargin = barPosition.top <= -barMarginTop; // 검색창의 상단이 화면 맨 위에 닿으면 true
+
+      setISFixedBar(isPassedMargin); // 화면에 검색창이 닿으면 고정 검색바 보여줌
+      setIsBlur(isPassedMargin); // 기존 검색바는 blur처리
+    };
+
+    window.addEventListener('scroll', handleScroll); // 사용자가 스크롤할 때마다 검색창 위치를 검사
+    return () => window.removeEventListener('scroll', handleScroll); // 메모리 누수 방지를 위한 이벤트 제거
+  }, [barMarginTop]);
+
+  return (
+    <>
+      {/* 원래 위치의 검색바, props로 className을 전달해서 높이 조절 가능 */}
+      <div ref={searchBarRef}>
+        <HomeSearchBar isBlur={isBlur} className={`mt-[${barMarginTop}px]`} />
+      </div>
+
+      {/* 스크롤 후 고정되는 검색바 */}
+      <AnimatePresence mode='wait'>
+        {isFixedBar && (
+          <motion.div
+            initial={{ y: -80, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: -80, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeInOut' }}
+            className='fixed w-full top-0 z-10 p-4'
+          >
+            <HomeSearchBar
+              isFixed={true}
+              className={clsx(isMobile ? '-translate-x-5' : '-translate-x/2')}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  );
+};
+
+export default ChangeSearchBar;

--- a/src/components/layout/searchBar/ChangeSearchBar.tsx
+++ b/src/components/layout/searchBar/ChangeSearchBar.tsx
@@ -4,6 +4,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { isMobile } from 'react-device-detect';
 import clsx from 'clsx';
 import HomeSearchBar from './HomeSearchBar';
+import Button from '@/components/common/Button';
+import { BackArrowIcon } from '@/assets';
 
 // props로 검색창의 top마진 값 전달 받음
 interface ChangeSearchBarProps {
@@ -36,24 +38,41 @@ const ChangeSearchBar = ({ barMarginTop }: ChangeSearchBarProps) => {
     <>
       {/* 원래 위치의 검색바, props로 className을 전달해서 높이 조절 가능 */}
       <div ref={searchBarRef}>
-        <HomeSearchBar isBlur={isBlur} className={`mt-[${barMarginTop}px]`} />
+        <HomeSearchBar isBlur={isBlur} style={{ marginTop: `${barMarginTop}px` }} />
       </div>
 
       {/* 스크롤 후 고정되는 검색바 */}
       <AnimatePresence mode='wait'>
         {isFixedBar && (
-          <motion.div
-            initial={{ y: -80, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: -80, opacity: 0 }}
-            transition={{ duration: 0.2, ease: 'easeInOut' }}
-            className='fixed w-full top-0 z-10 p-4'
-          >
-            <HomeSearchBar
-              isFixed={true}
-              className={clsx(isMobile ? '-translate-x-5' : '-translate-x/2')}
-            />
-          </motion.div>
+          <>
+            <motion.div
+              initial={{ y: -80, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              exit={{ y: -80, opacity: 0 }}
+              transition={{ duration: 0.2, ease: 'easeInOut' }}
+              className='fixed w-full top-0 z-10 p-4'
+            >
+              <HomeSearchBar
+                isFixed={true}
+                className={clsx(isMobile ? '-translate-x-5' : '-translate-x/2')}
+              />
+            </motion.div>
+            <motion.div
+              initial={{ rotate: 0, opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2, ease: 'easeInOut' }}
+              className='fixed w-full bottom-5 left-5 z-10'
+            >
+              <Button
+                icon={
+                  <BackArrowIcon width={24} height={24} strokeWidth={2.5} className='rotate-90' />
+                }
+                onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+                className='border-1 bg-lightGray rounded-full shadow-md p-4 border-lightGray hover:brightness-90 cursor-pointer'
+              />
+            </motion.div>
+          </>
         )}
       </AnimatePresence>
     </>

--- a/src/components/layout/searchBar/HomeSearchBar.tsx
+++ b/src/components/layout/searchBar/HomeSearchBar.tsx
@@ -11,6 +11,7 @@ interface IHomeSearchBarProps {
   className?: string;
   isFixed?: boolean;
   isBlur?: boolean;
+  style?: React.CSSProperties;
 }
 
 const inputStyle = tv({
@@ -68,7 +69,12 @@ const filterIconStyle = tv({
   },
 });
 
-const HomeSearchBar = ({ className, isFixed = false, isBlur = false }: IHomeSearchBarProps) => {
+const HomeSearchBar = ({
+  className,
+  style,
+  isFixed = false,
+  isBlur = false,
+}: IHomeSearchBarProps) => {
   const [searchContents, setSearchContents] = useAtom(searchContentsAtom);
   const navigate = useNavigate();
 
@@ -83,7 +89,7 @@ const HomeSearchBar = ({ className, isFixed = false, isBlur = false }: IHomeSear
 
   return (
     <div className='flex justify-center'>
-      <div className={clsx('relative w-4/5 max-w-[50rem] max-sm:w-9/10', className)}>
+      <div className={clsx('relative w-4/5 max-w-[50rem] max-sm:w-9/10', className)} style={style}>
         <Input
           value={searchContents}
           onChange={onChange}

--- a/src/components/layout/searchBar/HomeSearchBar.tsx
+++ b/src/components/layout/searchBar/HomeSearchBar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
+import { tv } from 'tailwind-variants';
 import { FilteringIcon, FixedFilteringIcon, SearchIcon } from '@/assets';
 import Input from '@/components/common/Input';
 import { searchContentsAtom } from '@/atoms';
@@ -9,9 +10,65 @@ import { useAtom } from 'jotai';
 interface IHomeSearchBarProps {
   className?: string;
   isFixed?: boolean;
+  isBlur?: boolean;
 }
 
-const HomeSearchBar = ({ className, isFixed = false }: IHomeSearchBarProps) => {
+const inputStyle = tv({
+  base: `w-full rounded-[100px] text-md px-[3rem] font-medium focus:outline-none placeholder-stone
+  border-2 border-[rgba(234,237,245,1)] shadow-[0_2px_7px_rgba(28,37,53,0.1)] transition duration-300`,
+  variants: {
+    isFixed: {
+      true: 'py-[0.5rem] mx-auto rounded-[100px] bg-[#FCFCFCCC]/80',
+      false: 'py-[1rem]',
+    },
+    isBlur: {
+      true: 'opacity-20',
+      false: 'opacity-100',
+    },
+  },
+  defaultVariants: {
+    isFixed: false,
+    isBlur: false,
+  },
+});
+
+const searchIconStyle = tv({
+  base: 'transition duration-300',
+  variants: {
+    isFixed: {
+      true: 'stroke-stone',
+      false: 'stroke-blue',
+    },
+    isBlur: {
+      true: 'opacity-20',
+      false: 'opacity-100',
+    },
+  },
+  defaultVariants: {
+    isFixed: false,
+    isBlur: false,
+  },
+});
+
+const filterIconStyle = tv({
+  base: 'absolute top-1/2 -translate-y-1/2 cursor-pointer hover:brightness-90 transition duration-300',
+  variants: {
+    isFixed: {
+      true: 'right-3',
+      false: 'right-1.5',
+    },
+    isBlur: {
+      true: 'opacity-20',
+      false: 'opacity-100',
+    },
+  },
+  defaultVariants: {
+    isFixed: false,
+    isBlur: false,
+  },
+});
+
+const HomeSearchBar = ({ className, isFixed = false, isBlur = false }: IHomeSearchBarProps) => {
   const [searchContents, setSearchContents] = useAtom(searchContentsAtom);
   const navigate = useNavigate();
 
@@ -30,24 +87,17 @@ const HomeSearchBar = ({ className, isFixed = false }: IHomeSearchBarProps) => {
         <Input
           value={searchContents}
           onChange={onChange}
-          className={clsx(
-            'w-full rounded-[100px] text-md px-[3rem] font-medium focus:outline-none placeholder-stone',
-            'border-2 border-[rgba(234,237,245,1)] shadow-[0_2px_7px_rgba(28,37,53,0.1)]',
-            isFixed ? 'py-[0.5rem] mx-auto rounded-[100px] bg-white' : 'py-[1rem]',
-          )}
+          className={inputStyle({ isFixed, isBlur })}
           onKeyDown={(e: React.KeyboardEvent<HTMLInputElement>) => {
             if (e.key === 'Enter') EnterFn();
           }}
           placeholder='제목, 태그 검색'
         />
         <div className='absolute left-5 top-1/2 -translate-y-1/2'>
-          <SearchIcon className={clsx(isFixed ? 'stroke-stone' : 'stroke-blue')} />
+          <SearchIcon className={searchIconStyle({ isFixed, isBlur })} />
         </div>
         <div
-          className={clsx(
-            'absolute top-1/2 -translate-y-1/2 cursor-pointer hover:brightness-90 transition',
-            isFixed ? 'right-3' : 'right-1.5',
-          )}
+          className={filterIconStyle({ isFixed, isBlur })}
           onClick={() => navigate('/search')} // 아이콘 누르면 /search로 이동
         >
           {isFixed ? <FixedFilteringIcon /> : <FilteringIcon />}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,15 +1,12 @@
 import SideBar from '@/components/layout/sidebar/SideBar';
-import HomeSearchBar from '@/components/layout/searchBar/HomeSearchBar';
+import ChangeSearchBar from '@/components/layout/searchBar/ChangeSearchBar';
 import CardList from '@/components/ui/cardlist/CardList';
 import MobileCardList from '@/components/ui/cardlist/MobileCardList';
 import { isMobile } from 'react-device-detect';
 import MobileHeader from '@/components/layout/header/MobileHeader';
 import { Outlet } from 'react-router-dom';
-import { useEffect, useRef, useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
 import HomeFooter from '@/components/layout/footer/HomeFooter';
 import LatestListHeader from '@/components/layout/header/LatestListHeader';
-import clsx from 'clsx';
 
 const Home = () => {
   const cardList = Array.from({ length: 11 }, (_, i) => ({
@@ -17,53 +14,13 @@ const Home = () => {
     title: `제목 ${i + 1}`,
   }));
 
-  const searchBarRef = useRef<HTMLDivElement>(null);
-  const [isFixedBar, setISFixedBar] = useState(false);
-
-  useEffect(() => {
-    const handleScroll = () => {
-      if (!searchBarRef.current) return; // 아직 검색창이 렌더링 되지 않았으면 종료
-
-      //검색창 DOM 요소의 위치 정보를 가져옴 (브라우저 뷰포트 기준)
-      // -> getBoundingClientRect()는 브라우저에서 뷰포트(화면) 내 위치를 알려주는 메서드
-      const barPosition = searchBarRef.current.getBoundingClientRect();
-      const barVisible = barPosition.bottom > 0; // 검색창의 하단이 화면 안에 보이면 true
-
-      // isSearchBarVisibledl false 즉, 화면에서 검색창이 완전히 사라지면 fixed 검색창 보여줌
-      setISFixedBar(!barVisible);
-    };
-
-    window.addEventListener('scroll', handleScroll); // 사용자가 스크롤할 때마다 검색창 위치를 검사
-    return () => window.removeEventListener('scroll', handleScroll); // 메모리 누수 방지를 위한 이벤트 제거
-  }, []);
-
   return (
     <div className='relative min-h-screen'>
       {/* 데스크탑일 경우 사이드바 나타남 */}
       {!isMobile ? <SideBar /> : <MobileHeader />}
 
-      {/* 원래 위치의 검색바, props로 className을 전달해서 높이 조절 가능 */}
-      <div ref={searchBarRef}>
-        <HomeSearchBar className='mt-[12.5rem]' />
-      </div>
-
-      {/* 스크롤 후 고정되는 검색바 */}
-      <AnimatePresence mode='wait'>
-        {isFixedBar && (
-          <motion.div
-            initial={{ y: -80, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: -80, opacity: 0 }}
-            transition={{ duration: 0.2, ease: 'easeInOut' }}
-            className='fixed w-full top-0 z-10 p-4'
-          >
-            <HomeSearchBar
-              isFixed={true}
-              className={clsx(isMobile ? '-translate-x-5' : '-translate-x/2')}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
+      {/* 검색창 마진값 설정 가능 */}
+      <ChangeSearchBar barMarginTop={200} />
 
       {/* 모바일/데스크탑 구분 */}
       {isMobile ? (


### PR DESCRIPTION
## 📂 관련 이슈

- closes #29 

<br>

## 🔀 PR 개요

- 홈 검색바가 스크롤 내릴 때 처리되는 방법 변경

<br>

## 📝 작업 내용

- 기존에 검색 바가 스크롤을 내려 완전히 사라져야 상단 고정 검색바가 뜨는 걸 화면 최상단에 닿는 순간 뜨도록 변경
  - 기존 검색바는 Blur처리

- `ChangeSearchBar`컴포넌트를 만들어 검색 바가 변경되는 로직을 분리
  -> `Home`에서는  `ChangeSearchBar`를 호출해서 사용

- **사용 시 주의 사항**
  - `ChangeSearchBar`을 호출할 때 `props`로 `barMarginTop`을 꼭 작성해줘야함
  - 직접 DOM에서 검색창의 높이를 계산하는 방법을 찾지 못해서 직접 설정해줘야함


<br>

## 📸 스크린샷


https://github.com/user-attachments/assets/c2657bca-3b79-455f-9095-9ae022312b1e



<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>

## 🔧 추가 사항

> 아직 완료 못한 작업, 리뷰어가 알면 좋은 내용, 향후 개선 아이디어 등

<br>
