### PR TITLE
[Feat] #50 kakao Login

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,5 +7,4 @@ function App() {
     </div>
   );
 }
-
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,14 @@
-import { Outlet } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router-dom';
 
-function App() {
-  return (
-    <div>
-      <Outlet />
-    </div>
-  );
-}
+const App = () => {
+  const accessToken = localStorage.getItem('accessToken');
+
+  // 로그인이 되어 있지 않으면 로그인 페이지로 이동
+  if (!accessToken) {
+    return <Navigate to='/login' />;
+  }
+
+  return <Outlet />;
+};
+
 export default App;

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
-import { Home, Login, Search, Save, Example, SearchResult, Edit } from '@/pages';
+import { Home, Login, Search, Save, Example, SearchResult, KakaoCallBack } from '@/pages';
 import App from '@/App';
 
 const router = createBrowserRouter([
@@ -19,17 +19,8 @@ const router = createBrowserRouter([
             path: 'search',
             element: <Search />,
           },
-          {
-            path: 'edit',
-            element: <Edit />,
-          },
         ],
       },
-      {
-        path: 'login',
-        element: <Login />,
-      },
-
       {
         path: 'search-result',
         element: <SearchResult />,
@@ -38,10 +29,6 @@ const router = createBrowserRouter([
             path: 'search',
             element: <Search />,
           },
-          {
-            path: 'edit',
-            element: <Edit />,
-          },
         ],
       },
       {
@@ -49,6 +36,14 @@ const router = createBrowserRouter([
         element: <Example />,
       },
     ],
+  },
+  {
+    path: '/login/',
+    element: <Login />,
+  },
+  {
+    path: '/auth/login/kakao',
+    element: <KakaoCallBack />,
   },
 ]);
 

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,0 +1,86 @@
+import axios from 'axios';
+
+const BASE_URL = import.meta.env.VITE_API_URL;
+
+// api 기본 설정
+const api = axios.create({
+  baseURL: BASE_URL,
+  timeout: 5000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// get refresh token
+const getRefreshToken = async () => {
+  const refreshToken = localStorage.getItem('refreshToken');
+  if (!refreshToken) throw new Error('refreshToken not found');
+
+  try {
+    const response = await api.post('/auth/reissue', {
+      refreshToken,
+    });
+    if (response.data.code === 200) {
+      const { accessToken, newRefreshToken } = response.data.data;
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('refreshToken', newRefreshToken);
+
+      return { accessToken, refreshToken: newRefreshToken };
+    } else {
+      throw new Error('refreshToken 갱신 실패');
+    }
+  } catch (error) {
+    console.error('refreshToken 요청 실패', error);
+    throw error;
+  }
+};
+
+// request interceptor
+api.interceptors.request.use(
+  async (config) => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (accessToken && config.headers) {
+      config.headers.Authorization = `Bearer ${accessToken}`;
+    }
+    return config;
+  },
+  (error) => {
+    console.error('request 실패', error);
+    return Promise.reject(error);
+  },
+);
+
+// response interceptor
+api.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    const { request } = error.config;
+
+    // login request error
+    if (request.url?.includes('/auth/login')) {
+      return Promise.reject(error);
+    }
+
+    if (error.response.status === 401 && !request._retry) {
+      request._retry = true;
+
+      try {
+        const { accessToken } = await getRefreshToken();
+        request.headers.Authorization = `Bearer ${accessToken}`;
+
+        return api(request);
+      } catch (refreshError) {
+        console.error('refreshToken 갱신 실패', refreshError);
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default api;

--- a/src/api/auth/auth_api.ts
+++ b/src/api/auth/auth_api.ts
@@ -1,0 +1,17 @@
+import api from '@/api/api';
+
+const kakaoLoginApi = async (code: string) => {
+  console.log('code', code);
+  try {
+    const response = await api.get('/auth/login/kakao', {
+      params: { code },
+    });
+    console.log('response', response);
+    return response.data.data;
+  } catch (error) {
+    console.error('kakao login 실패', error);
+    throw error;
+  }
+};
+
+export default kakaoLoginApi;

--- a/src/api/auth/auth_api.ts
+++ b/src/api/auth/auth_api.ts
@@ -1,12 +1,22 @@
 import api from '@/api/api';
 
+const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
+const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+
+const kakaoLogin = async () => {
+  try {
+    const KAKAO_LOGIN_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&scope=account_email,profile_nickname,profile_image,talk_message`;
+    window.location.href = KAKAO_LOGIN_URL;
+  } catch (error) {
+    console.error('카카오 로그인 URL 요청 실패:', error);
+  }
+};
+
 const kakaoLoginApi = async (code: string) => {
-  console.log('code', code);
   try {
     const response = await api.get('/auth/login/kakao', {
       params: { code },
     });
-    console.log('response', response);
     return response.data.data;
   } catch (error) {
     console.error('kakao login 실패', error);
@@ -14,4 +24,4 @@ const kakaoLoginApi = async (code: string) => {
   }
 };
 
-export default kakaoLoginApi;
+export { kakaoLogin, kakaoLoginApi };

--- a/src/components/layout/header/HomeHeader.tsx
+++ b/src/components/layout/header/HomeHeader.tsx
@@ -1,12 +1,22 @@
 import { ProfileIcon } from '@/assets';
 
 const HomeHeader = () => {
+  const profileImage = localStorage.getItem('profileImage');
+
   return (
     <div className='fixed flex sm:right-5 right-0 items-center px-2 pr-5 sm:mt-5 mt-6 z-50'>
-      <ProfileIcon
-        className='sm:w-[30px] sm:h-[30px] text-stone active:text-black'
-        fill={'white'}
-      />
+      {profileImage ? (
+        <img
+          src={profileImage}
+          alt='profile'
+          className='sm:w-[40px] sm:h-[40px] text-stone active:text-black rounded-[25%]'
+        />
+      ) : (
+        <ProfileIcon
+          className='sm:w-[30px] sm:h-[30px] text-stone active:text-black'
+          fill={'white'}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/layout/header/HomeHeader.tsx
+++ b/src/components/layout/header/HomeHeader.tsx
@@ -9,7 +9,7 @@ const HomeHeader = () => {
         <img
           src={profileImage}
           alt='profile'
-          className='sm:w-[40px] sm:h-[40px] text-stone active:text-black rounded-[25%]'
+          className='w-[40px] h-[40px] sm:w-[30px] sm:h-[30px] text-stone active:text-black rounded-[25%]'
         />
       ) : (
         <ProfileIcon

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,9 +9,18 @@ import SaveCardList from '@/components/ui/cardlist/SaveCardList';
 import { dummyCardData } from '@/contants/DummyData';
 import { getGroupedCardList } from '@/utils/GroupedCardList';
 import HomLogo from '@/components/ui/HomLogo';
+import { useEffect } from 'react';
 
 const Home = () => {
   const cardList = getGroupedCardList(dummyCardData);
+
+  useEffect(() => {
+    // 저장된 토큰 콘솔에 출력
+    const accessToken = localStorage.getItem('accessToken');
+    const refreshToken = localStorage.getItem('refreshToken');
+    console.log('🔑 Access Token:', accessToken);
+    console.log('🔄 Refresh Token:', refreshToken);
+  }, []);
 
   return (
     <div className='relative min-h-screen'>

--- a/src/pages/KakaoCallBack.tsx
+++ b/src/pages/KakaoCallBack.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
+import kakaoLoginApi from '@/api/auth/auth_api';
+
+function KakaoCallBack() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (accessToken) {
+      navigate('/', { replace: true }); // 이미 로그인된 경우 홈으로 이동
+    }
+  }, [navigate]);
+
+  const kakaoLoginMutation = useMutation({
+    mutationFn: kakaoLoginApi,
+    onSuccess: (res) => {
+      console.log('kakao login 성공', res);
+      localStorage.setItem('accessToken', res.jwtAccessToken);
+      localStorage.setItem('refreshToken', res.jwtRefreshToken);
+      localStorage.setItem('profileImage', res.profileImage);
+      navigate('/', { replace: true });
+    },
+    onError: () => {
+      console.error('kakao login 실패');
+      navigate('/login', { replace: true });
+    },
+  });
+
+  useEffect(() => {
+    const code = new URL(window.location.href).searchParams.get('code');
+    if (!code) {
+      console.log('Authorization code is not found');
+      return;
+    }
+    console.log('code', code);
+    kakaoLoginMutation.mutate(code);
+  }, []);
+
+  return <div>카카오 로그인 처리 중...</div>;
+}
+
+export default KakaoCallBack;

--- a/src/pages/KakaoCallBack.tsx
+++ b/src/pages/KakaoCallBack.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
-import kakaoLoginApi from '@/api/auth/auth_api';
+import { kakaoLoginApi } from '@/api/auth/auth_api';
 
 function KakaoCallBack() {
   const navigate = useNavigate();
@@ -34,8 +34,11 @@ function KakaoCallBack() {
       console.log('Authorization code is not found');
       return;
     }
-    console.log('code', code);
+    const cleanUrl = window.location.origin + window.location.pathname;
+    window.history.replaceState({}, document.title, cleanUrl);
+
     kakaoLoginMutation.mutate(code);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return <div>카카오 로그인 처리 중...</div>;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,14 +1,26 @@
 import { KakaoLogoIcon } from '@/assets';
 import Button from '@/components/common/Button';
-import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+
+const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
+const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+
+const KAKAO_LOGIN_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&scope=account_email,profile_nickname,profile_image,talk_message`;
 
 const Login = () => {
   const navigate = useNavigate();
 
   const handleKakaoLogin = () => {
-    console.log('카카오 로그인 클릭');
-    navigate('/home');
+    window.location.href = KAKAO_LOGIN_URL;
   };
+
+  useEffect(() => {
+    const accessToken = localStorage.getItem('accessToken');
+    if (accessToken) {
+      navigate('/', { replace: true }); // 이미 로그인된 경우 홈으로 이동
+    }
+  }, [navigate]);
 
   return (
     <div className='min-h-screen flex items-center justify-center bg-white px-4'>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,18 +1,14 @@
+import { kakaoLogin } from '@/api/auth/auth_api';
 import { KakaoLogoIcon } from '@/assets';
 import Button from '@/components/common/Button';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 
-const KAKAO_CLIENT_ID = import.meta.env.VITE_KAKAO_CLIENT_ID;
-const KAKAO_REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
-
-const KAKAO_LOGIN_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_CLIENT_ID}&redirect_uri=${KAKAO_REDIRECT_URI}&scope=account_email,profile_nickname,profile_image,talk_message`;
-
 const Login = () => {
   const navigate = useNavigate();
 
   const handleKakaoLogin = () => {
-    window.location.href = KAKAO_LOGIN_URL;
+    kakaoLogin();
   };
 
   useEffect(() => {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,6 +4,6 @@ import Save from './Save';
 import Search from './Search';
 import Example from './Example';
 import SearchResult from './SearchResult';
-import Edit from './Edit';
+import KakaoCallBack from './KakaoCallBack';
 
-export { Home, Login, Save, Search, Example, SearchResult, Edit };
+export { Home, Login, Save, Search, Example, SearchResult, KakaoCallBack };


### PR DESCRIPTION
## 📂 관련 이슈

- closes #50 

<br>

## 🔀 PR 개요

> kakao Login API 설정

<br>

## 📝 작업 내용

- api 및 interceptor 설정
- Kakao CallBack Page 구현
- kakao Login api 구현 및 토근 발급
- App에서 로그인 확인 후, 이동 절차 로직 구현
- 로그인이 되어 있을 때, 로그인 페이지 접근 하지 못하도록 구현

<br>

## 📸 스크린샷

<br>
<img width="125" height="103" alt="image" src="https://github.com/user-attachments/assets/e37f3e0b-06c1-4f8c-80f6-6df98ceea63a" />

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>

## 🔧 추가 사항

> 로그인 실패, 성공 시 Toast 나오도록 구현해야 됨

<br>
