### PR TITLE
[Feat] #53 Search History API 작업

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -72,9 +72,9 @@ api.interceptors.response.use(
         return api(request);
       } catch (refreshError) {
         console.error('refreshToken 갱신 실패', refreshError);
-        // localStorage.removeItem('accessToken');
-        // localStorage.removeItem('refreshToken');
-        // window.location.href = '/login';
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login';
         return Promise.reject(refreshError);
       }
     }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -63,7 +63,7 @@ api.interceptors.response.use(
       return Promise.reject(error);
     }
 
-    if (error.response && error.response.status === 403 && !request._retry) {
+    if (error.response && error.response.status === 401 && !request._retry) {
       request._retry = true;
       try {
         console.log('refreshToken 갱신');
@@ -72,9 +72,9 @@ api.interceptors.response.use(
         return api(request);
       } catch (refreshError) {
         console.error('refreshToken 갱신 실패', refreshError);
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
-        window.location.href = '/login';
+        // localStorage.removeItem('accessToken');
+        // localStorage.removeItem('refreshToken');
+        // window.location.href = '/login';
         return Promise.reject(refreshError);
       }
     }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -18,7 +18,7 @@ const getRefreshToken = async () => {
 
   try {
     const response = await api.post('/auth/reissue', {
-      refreshToken,
+      refreshToken: refreshToken,
     });
     if (response.data.code === 200) {
       const { accessToken, newRefreshToken } = response.data.data;
@@ -52,24 +52,23 @@ api.interceptors.request.use(
 
 // response interceptor
 api.interceptors.response.use(
-  (response) => {
-    return response;
-  },
+  (response) => response,
   async (error) => {
-    const { request } = error.config;
+    console.log('error', error);
+    const request = error.config;
+    if (!request) return Promise.reject(error);
 
-    // login request error
-    if (request.url?.includes('/auth/login')) {
+    // 토큰 갱신 요청은 무한 반복 방지
+    if (request.url?.includes('/auth/reissue')) {
       return Promise.reject(error);
     }
 
-    if (error.response.status === 401 && !request._retry) {
+    if (error.response && error.response.status === 403 && !request._retry) {
       request._retry = true;
-
       try {
+        console.log('refreshToken 갱신');
         const { accessToken } = await getRefreshToken();
         request.headers.Authorization = `Bearer ${accessToken}`;
-
         return api(request);
       } catch (refreshError) {
         console.error('refreshToken 갱신 실패', refreshError);

--- a/src/api/searchHistory/searchHistory_api.tsx
+++ b/src/api/searchHistory/searchHistory_api.tsx
@@ -1,0 +1,22 @@
+import api from '@/api/api';
+
+const getSearchHistory = async () => {
+  try {
+    const response = await api.get('/search-histories');
+    return response.data.data;
+  } catch (error) {
+    console.error('getSearchHistory 실패', error);
+    throw error;
+  }
+};
+
+const postSearchHistory = async (searchContent: string) => {
+  try {
+    const response = await api.post('/search-histories', { keyword: searchContent });
+    return response.data.data;
+  } catch (error) {
+    console.error('postSearchHistory 실패', error);
+    throw error;
+  }
+};
+export { getSearchHistory, postSearchHistory };

--- a/src/api/searchHistory/searchHistory_api.tsx
+++ b/src/api/searchHistory/searchHistory_api.tsx
@@ -19,4 +19,15 @@ const postSearchHistory = async (searchContent: string) => {
     throw error;
   }
 };
-export { getSearchHistory, postSearchHistory };
+
+const deleteSearchHistory = async (searchHistoryId: number) => {
+  try {
+    const response = await api.delete(`/search-histories/${searchHistoryId}`);
+    return response.data.data;
+  } catch (error) {
+    console.error('deleteSearchHistory 실패', error);
+    throw error;
+  }
+};
+
+export { getSearchHistory, postSearchHistory, deleteSearchHistory };

--- a/src/components/layout/searchBar/FilterSearchBar.tsx
+++ b/src/components/layout/searchBar/FilterSearchBar.tsx
@@ -56,17 +56,23 @@ const FilterSearchBar: React.FC = () => {
     },
   });
 
+  console.log(history);
+
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
     setSearchContents(e.currentTarget.value);
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+  const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && searchContents.trim()) {
-      // 검색어 조회 query 업데이트
-      postSearchHistory(searchContents);
-      refetch();
-      console.log('검색어:', searchContents);
-      setSearchContents('');
+      try {
+        // 검색어 조회 query 업데이트
+        await postSearchHistory(searchContents);
+        refetch();
+        console.log('검색어:', searchContents);
+        setSearchContents('');
+      } catch (error) {
+        console.error('검색 기록 저장 실패:', error);
+      }
     }
   };
 
@@ -171,7 +177,7 @@ const FilterSearchBar: React.FC = () => {
 
       {/* 최근 검색 기록 */}
       {isFocused && history.length > 0 && (
-        <div className='absolute top-full left-0 w-full  px-4 shadow-md z-0 bg-white border-t-2 border-lightGrayBlue'>
+        <div className='absolute top-full left-0 w-full  px-4 shadow-md z-0 bg-white border-t-2 border-lightGrayBlue hide-scrollbar'>
           {history.map(({ keyword, id }: { keyword: string; id: number }) => (
             <div
               key={id}

--- a/src/components/layout/searchBar/FilterSearchBar.tsx
+++ b/src/components/layout/searchBar/FilterSearchBar.tsx
@@ -5,6 +5,8 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useAtom } from 'jotai';
 import { selectedCategoriesAtom, selectedTagsAtom, selectedPlatformsAtom } from '@/atoms';
 import { useNavigate } from 'react-router-dom';
+import { getSearchHistory, postSearchHistory } from '@/api/searchHistory/searchHistory_api';
+import { useQuery } from '@tanstack/react-query';
 
 interface AnimatedHeightProps {
   show: boolean;
@@ -38,7 +40,6 @@ const AnimatedHeight: React.FC<AnimatedHeightProps> = ({ show, children }) => {
 const FilterSearchBar: React.FC = () => {
   const [searchContents, setSearchContents] = useState('');
   const [isFocused, setIsFocused] = useState(false);
-  const [history, setHistory] = useState<string[]>([]);
   const historyRef = useRef<HTMLDivElement>(null);
 
   const [selectedCategories, setSelectedCategories] = useAtom(selectedCategoriesAtom);
@@ -48,15 +49,22 @@ const FilterSearchBar: React.FC = () => {
   const navigate = useNavigate();
   const onPrev = () => navigate(-1);
 
+  const { data: history, refetch } = useQuery({
+    queryKey: ['searchHistory'],
+    queryFn: () => {
+      return getSearchHistory();
+    },
+  });
+
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
     setSearchContents(e.currentTarget.value);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter' && searchContents.trim()) {
-      setHistory((prev) =>
-        [searchContents, ...prev.filter((v) => v !== searchContents)].slice(0, 3),
-      );
+      // 검색어 조회 query 업데이트
+      postSearchHistory(searchContents);
+      refetch();
       console.log('검색어:', searchContents);
       setSearchContents('');
     }
@@ -65,7 +73,8 @@ const FilterSearchBar: React.FC = () => {
   const clearInput = () => setSearchContents('');
 
   const handleDeleteHistory = (target: string) => {
-    setHistory((prev) => prev.filter((item) => item !== target));
+    console.log(target);
+    //setHistory((prev) => prev.filter((item) => item !== target));
   };
 
   const handleDeleteCategory = (category: string) =>
@@ -163,17 +172,17 @@ const FilterSearchBar: React.FC = () => {
       {/* 최근 검색 기록 */}
       {isFocused && history.length > 0 && (
         <div className='absolute top-full left-0 w-full  px-4 shadow-md z-0 bg-white border-t-2 border-lightGrayBlue'>
-          {history.map((record, i) => (
+          {history.map(({ keyword, id }: { keyword: string; id: number }) => (
             <div
-              key={i}
+              key={id}
               className='flex items-center justify-between gap-2 my-4 text-15 text-black'
             >
               <div
                 className='flex items-center gap-2 cursor-pointer hover:underline'
-                onClick={() => setSearchContents(record)}
+                onClick={() => setSearchContents(keyword)}
               >
                 <HistoryIcon />
-                {record}
+                {keyword}
               </div>
               <Button
                 className='cursor-pointer'
@@ -182,7 +191,7 @@ const FilterSearchBar: React.FC = () => {
                   e.preventDefault();
                   e.stopPropagation();
                 }}
-                onClick={() => handleDeleteHistory(record)}
+                onClick={() => handleDeleteHistory(keyword)}
               />
             </div>
           ))}

--- a/src/components/layout/searchBar/FilterSearchBar.tsx
+++ b/src/components/layout/searchBar/FilterSearchBar.tsx
@@ -5,7 +5,11 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useAtom } from 'jotai';
 import { selectedCategoriesAtom, selectedTagsAtom, selectedPlatformsAtom } from '@/atoms';
 import { useNavigate } from 'react-router-dom';
-import { getSearchHistory, postSearchHistory } from '@/api/searchHistory/searchHistory_api';
+import {
+  deleteSearchHistory,
+  getSearchHistory,
+  postSearchHistory,
+} from '@/api/searchHistory/searchHistory_api';
 import { useQuery } from '@tanstack/react-query';
 
 interface AnimatedHeightProps {
@@ -56,8 +60,6 @@ const FilterSearchBar: React.FC = () => {
     },
   });
 
-  console.log(history);
-
   const onChange = (e: React.FormEvent<HTMLInputElement>) => {
     setSearchContents(e.currentTarget.value);
   };
@@ -78,9 +80,13 @@ const FilterSearchBar: React.FC = () => {
 
   const clearInput = () => setSearchContents('');
 
-  const handleDeleteHistory = (target: string) => {
-    console.log(target);
-    //setHistory((prev) => prev.filter((item) => item !== target));
+  const handleDeleteHistory = async (searchHistoryId: number) => {
+    try {
+      await deleteSearchHistory(searchHistoryId);
+      refetch();
+    } catch (error) {
+      console.error('검색 기록 삭제 실패:', error);
+    }
   };
 
   const handleDeleteCategory = (category: string) =>
@@ -177,7 +183,7 @@ const FilterSearchBar: React.FC = () => {
 
       {/* 최근 검색 기록 */}
       {isFocused && history.length > 0 && (
-        <div className='absolute top-full left-0 w-full  px-4 shadow-md z-0 bg-white border-t-2 border-lightGrayBlue hide-scrollbar'>
+        <div className='absolute top-full left-0 w-full px-4 shadow-md z-0 bg-white border-t-2 border-lightGrayBlue max-h-[128px] overflow-y-auto'>
           {history.map(({ keyword, id }: { keyword: string; id: number }) => (
             <div
               key={id}
@@ -192,12 +198,12 @@ const FilterSearchBar: React.FC = () => {
               </div>
               <Button
                 className='cursor-pointer'
-                icon={<DeleteIcon width={12} height={12} fill='#545966' />}
+                icon={<DeleteIcon width={12} height={12} stroke='#545966' />}
                 onMouseDown={(e) => {
                   e.preventDefault();
                   e.stopPropagation();
                 }}
-                onClick={() => handleDeleteHistory(keyword)}
+                onClick={() => handleDeleteHistory(id)}
               />
             </div>
           ))}

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -40,7 +40,9 @@ const Search = () => {
   const [tags, setTags] = useState<{ id: number; content: string }[]>([]);
   const navigate = useNavigate();
   const onPrev = () => navigate(-1);
-  useScrollLock(!isMobile);
+
+  // 스크롤 제한
+  useScrollLock(true);
 
   useEffect(() => {
     const onlyCategories = Array.from(new Set(dummyCardData.map((item) => item.category))).map(


### PR DESCRIPTION
## 📂 관련 이슈

- closes #53 

<br>

## 🔀 PR 개요

> SearchHistory API 작업

<br>

## 📝 작업 내용

- 토큰 만료 시, 토큰 재발급이 정상 작동하도록 수정
- Search History get 연결
- Search History post 연결
- Search History delete 연결
- Search History가 4개 이상일 경우 스크롤 바가 생기도록 구현

<br>

## 📸 스크린샷

https://github.com/user-attachments/assets/293dcbb2-00c5-4a47-bcbf-0893bb4bba92


<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>
