### PR TITLE
[Feat] #69 마이페이지, 카테고리/태그 관리 API 연결

### DIFF
--- a/src/api/tag/tag.ts
+++ b/src/api/tag/tag.ts
@@ -18,4 +18,19 @@ const getTags = async (categoryId: number): Promise<ApiResponse<TagProps[]>> => 
   });
 };
 
-export { createTag, getTags };
+const updateTag = async (tagId: number, tagName: string): Promise<ApiResponse<string>> => {
+  return apiRequest<string>({
+    method: 'PATCH',
+    url: `/tags/${tagId}`,
+    data: { tagName },
+  });
+};
+
+const deleteTag = async (tagId: number): Promise<ApiResponse<string>> => {
+  return apiRequest<string>({
+    method: 'DELETE',
+    url: `/tags/${tagId}`,
+  });
+};
+
+export { createTag, getTags, updateTag, deleteTag };

--- a/src/api/users/user.ts
+++ b/src/api/users/user.ts
@@ -9,4 +9,14 @@ const getUserInfo = async (): Promise<ApiResponse<UserInfoResponse>> => {
   });
 };
 
-export { getUserInfo };
+const updateUserNickname = async (nickname: string): Promise<ApiResponse<string>> => {
+  return apiRequest<string>({
+    method: 'PATCH',
+    url: '/users/me/nickname',
+    data: {
+      nickname,
+    },
+  });
+};
+
+export { getUserInfo, updateUserNickname };

--- a/src/api/users/user.ts
+++ b/src/api/users/user.ts
@@ -1,0 +1,12 @@
+import { apiRequest } from '@/api/api';
+import type { UserInfoResponse } from '@/types/api/users';
+import type { ApiResponse } from '@/types/common/api-response';
+
+const getUserInfo = async (): Promise<ApiResponse<UserInfoResponse>> => {
+  return apiRequest<UserInfoResponse>({
+    method: 'GET',
+    url: '/users/me',
+  });
+};
+
+export { getUserInfo };

--- a/src/components/ui/TextField.tsx
+++ b/src/components/ui/TextField.tsx
@@ -54,7 +54,6 @@ const TextField = ({
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter') {
       e.currentTarget.blur();
-      onBlur();
     }
   };
 

--- a/src/components/ui/card/CategoryCard.tsx
+++ b/src/components/ui/card/CategoryCard.tsx
@@ -40,6 +40,8 @@ const CategoryCard = ({
   const [isDisabled, setIsDisabled] = useState(true);
   const { isMenuOpen, menuPosition, iconRef, isOpen, isClose } = useMenuHandler(); // 아이콘 기반으로 메뉴바 위치를 설정하는 커스텀 훅
 
+  const allTagNames = tags.map((tag) => tag.tagName);
+
   const queryClient = useQueryClient();
 
   const schema = modalAddSchema('category', allCategoryNames);
@@ -172,7 +174,12 @@ const CategoryCard = ({
           >
             <div className='flex flex-wrap gap-2 p-0.5 mt-4'>
               {tags.map((tag) => (
-                <TagSettingChip key={tag.tagId} tagId={tag.tagId} tagName={tag.tagName} />
+                <TagSettingChip
+                  key={tag.tagId}
+                  tagId={tag.tagId}
+                  tagName={tag.tagName}
+                  allTagNames={allTagNames}
+                />
               ))}
             </div>
           </motion.div>

--- a/src/components/ui/card/CategoryCard.tsx
+++ b/src/components/ui/card/CategoryCard.tsx
@@ -37,7 +37,6 @@ const CategoryCard = ({
   const [isTagsOpen, setIsTagsOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [isDisabled, setIsDisabled] = useState(true);
   const { isMenuOpen, menuPosition, iconRef, isOpen, isClose } = useMenuHandler(); // 아이콘 기반으로 메뉴바 위치를 설정하는 커스텀 훅
 
   const allTagNames = tags.map((tag) => tag.tagName);
@@ -45,13 +44,16 @@ const CategoryCard = ({
   const queryClient = useQueryClient();
 
   const schema = modalAddSchema('category', allCategoryNames);
-  const { handleSubmit, control, reset } = useForm<z.infer<typeof schema>>({
+  const { handleSubmit, control, reset, formState } = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     mode: 'onChange',
     defaultValues: {
       category: '',
     },
   });
+
+  // Zod 스키마 유효성 검사 결과에 따라 disabled 상태 관리
+  const isDisabled = !formState.isValid || formState.isSubmitting;
 
   const { mutate: updateCategoryMutation } = useMutation({
     mutationFn: (categoryName: string) => updateCategory(categoryId, categoryName),
@@ -125,7 +127,6 @@ const CategoryCard = ({
     updateCategoryMutation(data.category);
     setIsModalOpen(false);
     reset();
-    setIsDisabled(true);
   };
 
   return (
@@ -210,7 +211,6 @@ const CategoryCard = ({
         onCancel={() => {
           setIsModalOpen(false);
           reset();
-          setIsDisabled(true);
         }}
         onConfirm={handleSubmit(handleConfirmModal)}
         disabled={isDisabled}
@@ -227,7 +227,6 @@ const CategoryCard = ({
               onChange={field.onChange}
               onBlur={field.onBlur}
               errorMessage={fieldState.error?.message}
-              setDisabled={(disabled: boolean) => setIsDisabled(disabled)}
             />
           )}
         />

--- a/src/components/ui/card/CategoryCard.tsx
+++ b/src/components/ui/card/CategoryCard.tsx
@@ -1,6 +1,6 @@
 import { BackArrowIcon, FolderDetailIcon } from '@/assets';
 import { Button } from '@/components/common';
-import { useMenuHandler } from '@/hooks/MenuPosition';
+import { useMenuHandler } from '@/hooks/menuPosition';
 import { MenuPortal, ModalPortal } from '@/utils';
 import clsx from 'clsx';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -14,20 +14,35 @@ import { useForm } from 'react-hook-form';
 import { Controller } from 'react-hook-form';
 import TextField from '../TextField';
 import TagSettingChip from '../chip/TagSettingChip';
+import type { CategoryWithTagProps, TagProps } from '@/types/api/category';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteCategory, updateCategory } from '@/api/category/category';
+import toast from 'react-hot-toast';
 
 interface CategoryCardProps {
   color: string;
+  categoryId: number;
   categoryName: string;
+  tags: TagProps[];
+  allCategoryNames: string[];
 }
 
-const CategoryCard = ({ color, categoryName }: CategoryCardProps) => {
+const CategoryCard = ({
+  color,
+  categoryId,
+  categoryName,
+  tags,
+  allCategoryNames,
+}: CategoryCardProps) => {
   const [isTagsOpen, setIsTagsOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
   const { isMenuOpen, menuPosition, iconRef, isOpen, isClose } = useMenuHandler(); // 아이콘 기반으로 메뉴바 위치를 설정하는 커스텀 훅
 
-  const schema = modalAddSchema('category');
+  const queryClient = useQueryClient();
+
+  const schema = modalAddSchema('category', allCategoryNames);
   const { handleSubmit, control, reset } = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     mode: 'onChange',
@@ -36,8 +51,79 @@ const CategoryCard = ({ color, categoryName }: CategoryCardProps) => {
     },
   });
 
+  const { mutate: updateCategoryMutation } = useMutation({
+    mutationFn: (categoryName: string) => updateCategory(categoryId, categoryName),
+    onMutate: async (newCategoryName) => {
+      // 진행 중인 쿼리 취소
+      await queryClient.cancelQueries({ queryKey: ['categoriesWithTag'] });
+
+      // 이전 데이터 백업
+      const previousCategories = queryClient.getQueryData(['categoriesWithTag']);
+
+      // 즉시 UI 업데이트 (낙관적 업데이트)
+      queryClient.setQueryData(['categoriesWithTag'], (old: any) => {
+        if (!old?.data) return old;
+        return {
+          ...old,
+          data: old.data.map((cat: CategoryWithTagProps) =>
+            cat.categoryId === categoryId ? { ...cat, categoryName: newCategoryName } : cat,
+          ),
+        };
+      });
+
+      return { previousCategories };
+    },
+    onSettled: (data, error, _, context) => {
+      if (data?.error || error) {
+        console.log(data);
+        console.log(error);
+        const errorMessage = data?.error ? data.message : error?.message || '알 수 없는 오류';
+        console.log('카테고리 수정 실패:', errorMessage);
+        queryClient.setQueryData(['categoriesWithTag'], context?.previousCategories);
+        toast.error('카테고리 수정 실패');
+        return;
+      }
+
+      toast.success('카테고리 수정 완료');
+      queryClient.invalidateQueries({ queryKey: ['categoriesWithTag'] });
+    },
+  });
+
+  const { mutate: deleteCategoryMutation } = useMutation({
+    mutationFn: (categoryId: number) => deleteCategory(categoryId),
+    onMutate: async (categoryId) => {
+      await queryClient.cancelQueries({ queryKey: ['categoriesWithTag'] });
+      const previousCategories = queryClient.getQueryData(['categoriesWithTag']);
+      queryClient.setQueryData(['categoriesWithTag'], (old: any) => {
+        if (!old?.data) return old;
+        return {
+          ...old,
+          data: old.data.filter((cat: CategoryWithTagProps) => cat.categoryId !== categoryId),
+        };
+      });
+
+      return { previousCategories };
+    },
+    onSettled: (data, error, _, context) => {
+      if (data?.error || error) {
+        const errorMessage = data?.error ? data.message : error?.message || '알 수 없는 오류';
+        console.log('카테고리 삭제 실패:', errorMessage);
+        queryClient.setQueryData(['categoriesWithTag'], context?.previousCategories);
+        toast.error('카테고리 삭제 실패');
+        return;
+      }
+
+      toast.success('카테고리 삭제 완료');
+      queryClient.invalidateQueries({ queryKey: ['categoriesWithTag'] });
+    },
+  });
+
   const handleConfirmModal = (data: z.infer<typeof schema>) => {
-    console.log(data);
+    if (!data.category.trim()) return;
+    updateCategoryMutation(data.category);
+    setIsModalOpen(false);
+    reset();
+    setIsDisabled(true);
   };
 
   return (
@@ -51,7 +137,7 @@ const CategoryCard = ({ color, categoryName }: CategoryCardProps) => {
         <div className='flex flex-row items-center justify-center gap-2'>
           <div className='w-3 h-3 rounded-[4px]' style={{ backgroundColor: color }} />
           <p className='text-base text-stone font-semibold'>{categoryName}</p>
-          <p className='text-base text-primary font-semibold'>15</p>
+          <p className='text-base text-primary font-semibold'>{tags.length}</p>
           <div ref={iconRef} onClick={isOpen}>
             <FolderDetailIcon
               width={24}
@@ -85,15 +171,9 @@ const CategoryCard = ({ color, categoryName }: CategoryCardProps) => {
             className='overflow-hidden'
           >
             <div className='flex flex-wrap gap-2 p-0.5 mt-4'>
-              <TagSettingChip />
-              <TagSettingChip />
-              <TagSettingChip />
-              <TagSettingChip />
-              <TagSettingChip />
-              <TagSettingChip />
-              <TagSettingChip />
-              <TagSettingChip />
-              <TagSettingChip />
+              {tags.map((tag) => (
+                <TagSettingChip key={tag.tagId} tagId={tag.tagId} tagName={tag.tagName} />
+              ))}
             </div>
           </motion.div>
         )}
@@ -170,6 +250,7 @@ const CategoryCard = ({ color, categoryName }: CategoryCardProps) => {
         }
         onDelete={() => {
           setIsDeleteModalOpen(false);
+          deleteCategoryMutation(categoryId);
         }}
       />
     </div>

--- a/src/components/ui/card/CategoryCard.tsx
+++ b/src/components/ui/card/CategoryCard.tsx
@@ -59,13 +59,13 @@ const CategoryCard = ({
     mutationFn: (categoryName: string) => updateCategory(categoryId, categoryName),
     onMutate: async (newCategoryName) => {
       // 진행 중인 쿼리 취소
-      await queryClient.cancelQueries({ queryKey: ['categoriesWithTag'] });
+      await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
 
       // 이전 데이터 백업
-      const previousCategories = queryClient.getQueryData(['categoriesWithTag']);
+      const previousCategories = queryClient.getQueryData(['categoriesWithTags']);
 
       // 즉시 UI 업데이트 (낙관적 업데이트)
-      queryClient.setQueryData(['categoriesWithTag'], (old: any) => {
+      queryClient.setQueryData(['categoriesWithTags'], (old: any) => {
         if (!old?.data) return old;
         return {
           ...old,
@@ -83,22 +83,22 @@ const CategoryCard = ({
         console.log(error);
         const errorMessage = data?.error ? data.message : error?.message || '알 수 없는 오류';
         console.log('카테고리 수정 실패:', errorMessage);
-        queryClient.setQueryData(['categoriesWithTag'], context?.previousCategories);
+        queryClient.setQueryData(['categoriesWithTags'], context?.previousCategories);
         toast.error('카테고리 수정 실패');
         return;
       }
 
       toast.success('카테고리 수정 완료');
-      queryClient.invalidateQueries({ queryKey: ['categoriesWithTag'] });
+      queryClient.invalidateQueries({ queryKey: ['categoriesWithTags'] });
     },
   });
 
   const { mutate: deleteCategoryMutation } = useMutation({
     mutationFn: (categoryId: number) => deleteCategory(categoryId),
     onMutate: async (categoryId) => {
-      await queryClient.cancelQueries({ queryKey: ['categoriesWithTag'] });
-      const previousCategories = queryClient.getQueryData(['categoriesWithTag']);
-      queryClient.setQueryData(['categoriesWithTag'], (old: any) => {
+      await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
+      const previousCategories = queryClient.getQueryData(['categoriesWithTags']);
+      queryClient.setQueryData(['categoriesWithTags'], (old: any) => {
         if (!old?.data) return old;
         return {
           ...old,
@@ -112,13 +112,13 @@ const CategoryCard = ({
       if (data?.error || error) {
         const errorMessage = data?.error ? data.message : error?.message || '알 수 없는 오류';
         console.log('카테고리 삭제 실패:', errorMessage);
-        queryClient.setQueryData(['categoriesWithTag'], context?.previousCategories);
+        queryClient.setQueryData(['categoriesWithTags'], context?.previousCategories);
         toast.error('카테고리 삭제 실패');
         return;
       }
 
       toast.success('카테고리 삭제 완료');
-      queryClient.invalidateQueries({ queryKey: ['categoriesWithTag'] });
+      queryClient.invalidateQueries({ queryKey: ['categoriesWithTags'] });
     },
   });
 

--- a/src/components/ui/card/FolderCard.tsx
+++ b/src/components/ui/card/FolderCard.tsx
@@ -25,9 +25,11 @@ const TitleText =
 
 const FolderCard = ({
   category,
+  allCategoryNames,
   pages,
 }: {
   category: CategoryProps;
+  allCategoryNames: string[];
   pages?: [number, number, number, () => void];
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -39,7 +41,7 @@ const FolderCard = ({
   // useScrollLock을 최상위로 이동
   useScrollLock(isScrollLocked);
 
-  const schema = modalAddSchema('category');
+  const schema = modalAddSchema('category', allCategoryNames);
   const queryClient = useQueryClient();
   const { handleSubmit, control, reset } = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),

--- a/src/components/ui/card/FolderCard.tsx
+++ b/src/components/ui/card/FolderCard.tsx
@@ -64,12 +64,15 @@ const FolderCard = ({
       const previousCategories = queryClient.getQueryData(['categories']);
 
       // 즉시 UI 업데이트 (낙관적 업데이트)
-      queryClient.setQueryData(['categories'], (old: any) => ({
-        ...old,
-        data: old.data.map((cat: CategoryProps) =>
-          cat.id === category.id ? { ...cat, categoryName: newCategoryName } : cat,
-        ),
-      }));
+      queryClient.setQueryData(['categories'], (old: any) => {
+        if (!old?.data) return old;
+        return {
+          ...old,
+          data: old.data.map((cat: CategoryProps) =>
+            cat.id === category.id ? { ...cat, categoryName: newCategoryName } : cat,
+          ),
+        };
+      });
 
       return { previousCategories };
     },
@@ -79,6 +82,7 @@ const FolderCard = ({
         console.log('카테고리 수정 실패:', errorMessage);
         queryClient.setQueryData(['categories'], context?.previousCategories);
         toast.error('카테고리 수정 실패');
+        return;
       }
 
       toast.success('카테고리 수정 완료');
@@ -91,10 +95,13 @@ const FolderCard = ({
     onMutate: async (categoryId) => {
       await queryClient.cancelQueries({ queryKey: ['categories'] });
       const previousCategories = queryClient.getQueryData(['categories']);
-      queryClient.setQueryData(['categories'], (old: any) => ({
-        ...old,
-        data: old.data.filter((cat: CategoryProps) => cat.id !== categoryId),
-      }));
+      queryClient.setQueryData(['categories'], (old: any) => {
+        if (!old?.data) return old;
+        return {
+          ...old,
+          data: old.data.filter((cat: CategoryProps) => cat.id !== categoryId),
+        };
+      });
 
       // 삭제 후 페이지 조정
       if (!isMobile && pages) {
@@ -115,6 +122,7 @@ const FolderCard = ({
         console.log('카테고리 삭제 실패:', errorMessage);
         queryClient.setQueryData(['categories'], context?.previousCategories);
         toast.error('카테고리 삭제 실패');
+        return;
       }
 
       toast.success('카테고리 삭제 완료');

--- a/src/components/ui/cardList/CardList.tsx
+++ b/src/components/ui/cardList/CardList.tsx
@@ -27,6 +27,8 @@ const CardList = ({ categories }: { categories: CategoryProps[] }) => {
   const [cardsPerSlide, setCardsPerSlide] = useState(getCardsPerSlide()); // 초기 계산
   const queryClient = useQueryClient();
 
+  const allCategoryNames = categories.map((cat) => cat.categoryName);
+
   // 현재 카드 수에 따라 최대 슬라이드 인덱스 계산
   const maxIndex =
     categories.length === 0 ? 0 : Math.floor((categories.length - 1) / cardsPerSlide);
@@ -144,6 +146,7 @@ const CardList = ({ categories }: { categories: CategoryProps[] }) => {
               <FolderCard
                 key={category.id}
                 category={category}
+                allCategoryNames={allCategoryNames}
                 pages={[index, categories.length, cardsPerSlide, decreaseIndex]}
               />
             ))}
@@ -152,7 +155,11 @@ const CardList = ({ categories }: { categories: CategoryProps[] }) => {
         {/** 보이지 않는 카드 리스트를 렌더링 해서 부모 div의 높이가 유지되도록 레이아웃을 보정함 */}
         <div className='invisible flex w-full'>
           {cardSlice.map((categories) => (
-            <FolderCard key={`ghost-${categories.id}`} category={categories} />
+            <FolderCard
+              key={`ghost-${categories.id}`}
+              category={categories}
+              allCategoryNames={allCategoryNames}
+            />
           ))}
         </div>
       </div>

--- a/src/components/ui/cardList/MobileCardList.tsx
+++ b/src/components/ui/cardList/MobileCardList.tsx
@@ -11,6 +11,8 @@ const MobileCardList = ({ categories }: { categories: CategoryProps[] }) => {
   const containerRef = useRef<HTMLDivElement>(null); // 외부 컨테이너 영역 (실제 보이는 영역)
   const [constraints, setConstraints] = useState({ left: 0, right: 0 }); // 드래그 제약 범위 상태값
 
+  const allCategoryNames = categories.map((cat) => cat.categoryName);
+
   // 카드 리스트 또는 브라우저 크기 변경 시 드래그 범위 재계산
   useEffect(() => {
     const updateConstraints = () => {
@@ -62,7 +64,7 @@ const MobileCardList = ({ categories }: { categories: CategoryProps[] }) => {
           className='flex justify-start items-center gap-3 cursor-grab active:cursor-grabbing'
         >
           {categories.map((category) => (
-            <FolderCard key={category.id} category={category} />
+            <FolderCard key={category.id} category={category} allCategoryNames={allCategoryNames} />
           ))}
         </motion.div>
       </div>

--- a/src/components/ui/chip/TagSettingChip.tsx
+++ b/src/components/ui/chip/TagSettingChip.tsx
@@ -8,7 +8,12 @@ import type z from 'zod';
 import TextField from '../TextField';
 import DeleteModal from '../modal/DeleteModal';
 
-const TagSettingChip = () => {
+interface TagSettingChipProps {
+  tagId: number;
+  tagName: string;
+}
+
+const TagSettingChip = ({ tagId, tagName }: TagSettingChipProps) => {
   const [isSelected, setIsSelected] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -30,7 +35,7 @@ const TagSettingChip = () => {
   return (
     <div>
       <Chip
-        content='태그 이름'
+        content={tagName}
         isSelected={isSelected}
         onClick={() => {
           setIsSelected(true);
@@ -63,7 +68,7 @@ const TagSettingChip = () => {
           render={({ field, fieldState }) => (
             <TextField
               label='이름'
-              placeholder={'태그 이름'}
+              placeholder={tagName}
               maxLength={10}
               value={field.value}
               onChange={field.onChange}
@@ -90,7 +95,7 @@ const TagSettingChip = () => {
       <DeleteModal
         isOpen={isDeleteModalOpen}
         onCancel={() => setIsDeleteModalOpen(false)}
-        warningText={`... 태그를 삭제할까요?`}
+        warningText={`${tagName} 태그를 삭제할까요?`}
         subText={'삭제시 태그만 삭제되며, 링크는 남아있습니다'}
         onDelete={() => {
           setIsDeleteModalOpen(false);

--- a/src/components/ui/chip/TagSettingChip.tsx
+++ b/src/components/ui/chip/TagSettingChip.tsx
@@ -18,16 +18,17 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
   const [isSelected, setIsSelected] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [isDisabled, setIsDisabled] = useState(true);
-
   const schema = modalAddSchema('tag', allTagNames);
-  const { handleSubmit, control, reset } = useForm<z.infer<typeof schema>>({
+  const { handleSubmit, control, reset, formState } = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     mode: 'onChange',
     defaultValues: {
       tag: '',
     },
   });
+
+  // Zod 스키마 유효성 검사 결과에 따라 disabled 상태 관리
+  const isDisabled = !formState.isValid || formState.isSubmitting;
 
   const handleConfirmModal = (data: z.infer<typeof schema>) => {
     console.log(data);
@@ -58,7 +59,6 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
           setIsSelected(false);
           setIsModalOpen(false);
           reset();
-          setIsDisabled(true);
         }}
         onConfirm={handleSubmit(handleConfirmModal)}
         disabled={isDisabled}
@@ -75,7 +75,6 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
               onChange={field.onChange}
               onBlur={field.onBlur}
               errorMessage={fieldState.error?.message}
-              setDisabled={(disabled: boolean) => setIsDisabled(disabled)}
             />
           )}
         />

--- a/src/components/ui/chip/TagSettingChip.tsx
+++ b/src/components/ui/chip/TagSettingChip.tsx
@@ -40,15 +40,18 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
     mutationFn: (tagName: string) => updateTag(tagId, tagName),
     onMutate: async (newTagName) => {
       // 진행 중인 쿼리 취소
-      await queryClient.cancelQueries({ queryKey: ['categoriesWithTag'] });
+      await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
 
       // 이전 데이터 백업
-      const previousCategories = queryClient.getQueryData(['categoriesWithTag']);
+      const previousCategories = queryClient.getQueryData(['categoriesWithTags']);
 
       // 즉시 UI 업데이트 (낙관적 업데이트)
-      queryClient.setQueryData(['categoriesWithTag'], (old: any) => {
+      queryClient.setQueryData(['categoriesWithTags'], (old: any) => {
         if (!old?.data) return old;
-        return {
+
+        console.log('낙관적 업데이트 전:', old.data);
+
+        const updatedData = {
           ...old,
           data: old.data.map((category: CategoryWithTagProps) => ({
             ...category,
@@ -57,6 +60,9 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
             ),
           })),
         };
+
+        console.log('낙관적 업데이트 후:', updatedData.data);
+        return updatedData;
       });
 
       return { previousCategories };
@@ -67,22 +73,22 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
         console.log(error);
         const errorMessage = data?.error ? data.message : error?.message || '알 수 없는 오류';
         console.log('태그 수정 실패:', errorMessage);
-        queryClient.setQueryData(['categoriesWithTag'], context?.previousCategories);
+        queryClient.setQueryData(['categoriesWithTags'], context?.previousCategories);
         toast.error('태그 수정 실패');
         return;
       }
 
       toast.success('태그 수정 완료');
-      queryClient.invalidateQueries({ queryKey: ['categoriesWithTag'] });
+      queryClient.invalidateQueries({ queryKey: ['categoriesWithTags'] });
     },
   });
 
   const { mutate: deleteTagMutation } = useMutation({
     mutationFn: (tagId: number) => deleteTag(tagId),
     onMutate: async (tagId) => {
-      await queryClient.cancelQueries({ queryKey: ['categoriesWithTag'] });
-      const previousCategories = queryClient.getQueryData(['categoriesWithTag']);
-      queryClient.setQueryData(['categoriesWithTag'], (old: any) => {
+      await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
+      const previousCategories = queryClient.getQueryData(['categoriesWithTags']);
+      queryClient.setQueryData(['categoriesWithTags'], (old: any) => {
         if (!old?.data) return old;
         return {
           ...old,
@@ -99,19 +105,28 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
       if (data?.error || error) {
         const errorMessage = data?.error ? data.message : error?.message || '알 수 없는 오류';
         console.log('태그 삭제 실패:', errorMessage);
-        queryClient.setQueryData(['categoriesWithTag'], context?.previousCategories);
+        queryClient.setQueryData(['categoriesWithTags'], context?.previousCategories);
         toast.error('태그 삭제 실패');
         return;
       }
 
       toast.success('태그 삭제 완료');
-      queryClient.invalidateQueries({ queryKey: ['categoriesWithTag'] });
+      queryClient.invalidateQueries({ queryKey: ['categoriesWithTags'] });
     },
   });
 
   const handleConfirmModal = (data: z.infer<typeof schema>) => {
     if (!data.tag.trim()) return;
+
+    console.log('태그 수정 시작:', data.tag);
     updateTagMutation(data.tag);
+
+    // 임시로 즉시 UI 업데이트 확인
+    setTimeout(() => {
+      const currentData = queryClient.getQueryData(['categoriesWithTags']);
+      console.log('수정 후 캐시 데이터:', currentData);
+    }, 100);
+
     setIsModalOpen(false);
     setIsSelected(false);
     reset();

--- a/src/components/ui/chip/TagSettingChip.tsx
+++ b/src/components/ui/chip/TagSettingChip.tsx
@@ -7,6 +7,11 @@ import { Controller, useForm } from 'react-hook-form';
 import type z from 'zod';
 import TextField from '../TextField';
 import DeleteModal from '../modal/DeleteModal';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateTag } from '@/api/tag/tag';
+import { deleteTag } from '@/api/tag/tag';
+import toast from 'react-hot-toast';
+import type { CategoryWithTagProps, TagProps } from '@/types/api/category';
 
 interface TagSettingChipProps {
   tagId: number;
@@ -27,11 +32,89 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
     },
   });
 
+  const queryClient = useQueryClient();
   // Zod 스키마 유효성 검사 결과에 따라 disabled 상태 관리
   const isDisabled = !formState.isValid || formState.isSubmitting;
 
+  const { mutate: updateTagMutation } = useMutation({
+    mutationFn: (tagName: string) => updateTag(tagId, tagName),
+    onMutate: async (newTagName) => {
+      // 진행 중인 쿼리 취소
+      await queryClient.cancelQueries({ queryKey: ['categoriesWithTag'] });
+
+      // 이전 데이터 백업
+      const previousCategories = queryClient.getQueryData(['categoriesWithTag']);
+
+      // 즉시 UI 업데이트 (낙관적 업데이트)
+      queryClient.setQueryData(['categoriesWithTag'], (old: any) => {
+        if (!old?.data) return old;
+        return {
+          ...old,
+          data: old.data.map((category: CategoryWithTagProps) => ({
+            ...category,
+            tags: category.tags.map((tag: TagProps) =>
+              tag.tagId === tagId ? { ...tag, tagName: newTagName } : tag,
+            ),
+          })),
+        };
+      });
+
+      return { previousCategories };
+    },
+    onSettled: (data, error, _, context) => {
+      if (data?.error || error) {
+        console.log(data);
+        console.log(error);
+        const errorMessage = data?.error ? data.message : error?.message || '알 수 없는 오류';
+        console.log('태그 수정 실패:', errorMessage);
+        queryClient.setQueryData(['categoriesWithTag'], context?.previousCategories);
+        toast.error('태그 수정 실패');
+        return;
+      }
+
+      toast.success('태그 수정 완료');
+      queryClient.invalidateQueries({ queryKey: ['categoriesWithTag'] });
+    },
+  });
+
+  const { mutate: deleteTagMutation } = useMutation({
+    mutationFn: (tagId: number) => deleteTag(tagId),
+    onMutate: async (tagId) => {
+      await queryClient.cancelQueries({ queryKey: ['categoriesWithTag'] });
+      const previousCategories = queryClient.getQueryData(['categoriesWithTag']);
+      queryClient.setQueryData(['categoriesWithTag'], (old: any) => {
+        if (!old?.data) return old;
+        return {
+          ...old,
+          data: old.data.map((category: CategoryWithTagProps) => ({
+            ...category,
+            tags: category.tags.filter((tag: TagProps) => tag.tagId !== tagId),
+          })),
+        };
+      });
+
+      return { previousCategories };
+    },
+    onSettled: (data, error, _, context) => {
+      if (data?.error || error) {
+        const errorMessage = data?.error ? data.message : error?.message || '알 수 없는 오류';
+        console.log('태그 삭제 실패:', errorMessage);
+        queryClient.setQueryData(['categoriesWithTag'], context?.previousCategories);
+        toast.error('태그 삭제 실패');
+        return;
+      }
+
+      toast.success('태그 삭제 완료');
+      queryClient.invalidateQueries({ queryKey: ['categoriesWithTag'] });
+    },
+  });
+
   const handleConfirmModal = (data: z.infer<typeof schema>) => {
-    console.log(data);
+    if (!data.tag.trim()) return;
+    updateTagMutation(data.tag);
+    setIsModalOpen(false);
+    setIsSelected(false);
+    reset();
   };
 
   return (
@@ -99,6 +182,7 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
         subText={'삭제시 태그만 삭제되며, 링크는 남아있습니다'}
         onDelete={() => {
           setIsDeleteModalOpen(false);
+          deleteTagMutation(tagId);
         }}
       />
     </div>

--- a/src/components/ui/chip/TagSettingChip.tsx
+++ b/src/components/ui/chip/TagSettingChip.tsx
@@ -11,15 +11,16 @@ import DeleteModal from '../modal/DeleteModal';
 interface TagSettingChipProps {
   tagId: number;
   tagName: string;
+  allTagNames: string[];
 }
 
-const TagSettingChip = ({ tagId, tagName }: TagSettingChipProps) => {
+const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) => {
   const [isSelected, setIsSelected] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [isDisabled, setIsDisabled] = useState(true);
 
-  const schema = modalAddSchema('tag');
+  const schema = modalAddSchema('tag', allTagNames);
   const { handleSubmit, control, reset } = useForm<z.infer<typeof schema>>({
     resolver: zodResolver(schema),
     mode: 'onChange',

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -25,8 +25,12 @@ const Home = () => {
   // 카테고리 조회
   const { data: categories, isPending } = useQuery({
     queryKey: ['categories'],
-    queryFn: () => {
-      return getCategories();
+    queryFn: async () => {
+      const res = await getCategories();
+      if (res.error) {
+        throw new Error(res.message);
+      }
+      return res.data;
     },
   });
 
@@ -43,9 +47,9 @@ const Home = () => {
       ) : (
         <>
           {isMobile ? (
-            <MobileCardList categories={categories?.data || []} />
+            <MobileCardList categories={categories || []} />
           ) : (
-            <CardList categories={categories?.data || []} />
+            <CardList categories={categories || []} />
           )}
         </>
       )}

--- a/src/pages/myPage/CategoryManagement.tsx
+++ b/src/pages/myPage/CategoryManagement.tsx
@@ -1,5 +1,8 @@
+import { getCategoriesWithTag } from '@/api/category/category';
 import CommonHeader from '@/components/layout/header/CommonHeader';
 import CategoryCard from '@/components/ui/card/CategoryCard';
+import Loading from '@/components/ui/loading/Loading';
+import { useQuery } from '@tanstack/react-query';
 import clsx from 'clsx';
 import { isMobile } from 'react-device-detect';
 
@@ -15,12 +18,16 @@ const categoryColors = [
 ];
 
 const CategoryManagement = () => {
-  // 10개의 카테고리 카드 더미 데이터
-  const categoryCards = Array.from({ length: 10 }, (_, index) => ({
-    id: index,
-    color: categoryColors[index % categoryColors.length],
-    name: `카테고리 ${index + 1}`,
-  }));
+  const { data: categoriesWithTag, isPending } = useQuery({
+    queryKey: ['categoriesWithTag'],
+    queryFn: async () => {
+      const res = await getCategoriesWithTag();
+      if (res.error) {
+        throw new Error(res.message);
+      }
+      return res.data;
+    },
+  });
 
   return (
     <div>
@@ -41,9 +48,17 @@ const CategoryManagement = () => {
             카테고리 / 태그 관리
           </p>
         )}
-        {categoryCards.map((card) => (
-          <CategoryCard key={card.id} color={card.color} categoryName={card.name} />
-        ))}
+        {isPending ? (
+          <Loading className='w-[96px] h-[96px] mx-5' />
+        ) : (
+          categoriesWithTag?.map((card, index) => (
+            <CategoryCard
+              key={card.categoryId}
+              color={categoryColors[index % categoryColors.length]}
+              categoryName={card.categoryName}
+            />
+          ))
+        )}
       </div>
     </div>
   );

--- a/src/pages/myPage/CategoryManagement.tsx
+++ b/src/pages/myPage/CategoryManagement.tsx
@@ -19,7 +19,7 @@ const categoryColors = [
 
 const CategoryManagement = () => {
   const { data: categoriesWithTag, isPending } = useQuery({
-    queryKey: ['categoriesWithTag'],
+    queryKey: ['categoriesWithTags'],
     queryFn: async () => {
       const res = await getCategoriesWithTag();
       if (res.error) {

--- a/src/pages/myPage/CategoryManagement.tsx
+++ b/src/pages/myPage/CategoryManagement.tsx
@@ -29,6 +29,9 @@ const CategoryManagement = () => {
     },
   });
 
+  // 카테고리 이름만 리스트로 추출
+  const allCategoryNames = categoriesWithTag?.map((category) => category.categoryName) || [];
+
   return (
     <div>
       {/* 헤더 */}
@@ -55,7 +58,10 @@ const CategoryManagement = () => {
             <CategoryCard
               key={card.categoryId}
               color={categoryColors[index % categoryColors.length]}
+              categoryId={card.categoryId}
               categoryName={card.categoryName}
+              allCategoryNames={allCategoryNames}
+              tags={card.tags}
             />
           ))
         )}

--- a/src/pages/myPage/Container.tsx
+++ b/src/pages/myPage/Container.tsx
@@ -88,7 +88,7 @@ const MyPage = () => {
                 </Button>
 
                 <button
-                  className='absolute bottom-8 left-5 p-3 text-stone rounded-[10px] border-2 border-lightGrayBlue text-15 font-medium flex items-center justify-center gap-2 cursor-pointer'
+                  className='absolute bottom-8 left-5 p-3 text-stone rounded-[10px] border-2 border-lightGrayBlue text-15 font-medium flex items-center justify-center gap-2 cursor-pointer hover:bg-gray-100'
                   onClick={() => {
                     handleLogout();
                   }}

--- a/src/pages/myPage/Container.tsx
+++ b/src/pages/myPage/Container.tsx
@@ -87,15 +87,17 @@ const MyPage = () => {
                   문의하기
                 </Button>
 
-                <Button
-                  className='absolute bottom-8 left-5 w-[124px] h-[48px] text-stone rounded-[10px] border-2 border-lightGrayBlue text-15 font-medium flex items-center justify-center gap-2 cursor-pointer'
-                  icon={<LogoutIcon width={20} height={20} />}
+                <button
+                  className='absolute bottom-8 left-5 p-3 text-stone rounded-[10px] border-2 border-lightGrayBlue text-15 font-medium flex items-center justify-center gap-2 cursor-pointer'
                   onClick={() => {
                     handleLogout();
                   }}
                 >
-                  로그아웃
-                </Button>
+                  <div className='flex items-center justify-center gap-2'>
+                    <LogoutIcon width={20} height={20} />
+                    <p className='hidden md:block text-15 font-medium'>로그아웃</p>
+                  </div>
+                </button>
               </div>
             </div>
 

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal } from '@/components/common';
+import { Button, Image, Modal } from '@/components/common';
 import CommonHeader from '@/components/layout/header/CommonHeader';
 import { LogoutIcon } from '@/assets';
 import { useNavigate } from 'react-router-dom';
@@ -69,18 +69,13 @@ const MyPage = () => {
             <div className='w-[128px] h-[128px] rounded-[40px] bg-gray-200' />
           ) : (
             <>
-              <Button
-                icon={
-                  <img
-                    src={userInfo?.profileImage}
-                    alt='profile'
-                    className='w-[128px] h-[128px] rounded-[40px]'
-                  />
-                }
+              <Image
+                src={userInfo?.profileImage || ''}
+                alt='profile'
+                className='w-[128px] h-[128px] rounded-[40px]'
                 onClick={() => {
                   navigate('/my-page/profile-edit');
                 }}
-                className='cursor-pointer'
               />
               <div className='flex flex-col justify-center gap-4'>
                 <p className='text-2xl font-semibold'>{userInfo?.nickname}</p>

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -7,11 +7,12 @@ import copy from 'copy-to-clipboard';
 import toast from 'react-hot-toast';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getUserInfo } from '@/api/users/user';
 
 const MyPage = () => {
   const navigate = useNavigate();
   const [isInquiryModalOpen, setIsInquiryModalOpen] = useState(false);
-  const profileImage = localStorage.getItem('profileImage');
 
   useEffect(() => {
     if (!isMobile) {
@@ -39,6 +40,18 @@ const MyPage = () => {
     navigate('/login');
   };
 
+  // 유저 정보 조회 API
+  const { data: userInfo, isPending } = useQuery({
+    queryKey: ['userInfo'],
+    queryFn: async () => {
+      const res = await getUserInfo();
+      if (res.error) {
+        throw new Error(res.message);
+      }
+      return res.data;
+    },
+  });
+
   return (
     <>
       {/* 헤더 */}
@@ -52,23 +65,29 @@ const MyPage = () => {
           className='w-[351px] flex flex-row items-center rounded-[40px] border-2 border-lightGrayBlue p-4 gap-6'
           style={{ boxShadow: '0 2px 7px 0 rgba(2, 34, 94, 0.1)' }}
         >
-          <Button
-            icon={
-              <img
-                src={profileImage || ''}
-                alt='profile'
-                className='w-[128px] h-[128px] rounded-[40px]'
+          {isPending ? (
+            <div className='w-[128px] h-[128px] rounded-[40px] bg-gray-200' />
+          ) : (
+            <>
+              <Button
+                icon={
+                  <img
+                    src={userInfo?.profileImage}
+                    alt='profile'
+                    className='w-[128px] h-[128px] rounded-[40px]'
+                  />
+                }
+                onClick={() => {
+                  navigate('/my-page/profile-edit');
+                }}
+                className='cursor-pointer'
               />
-            }
-            onClick={() => {
-              navigate('/my-page/profile-edit');
-            }}
-            className='cursor-pointer'
-          />
-          <div className='flex flex-col justify-center gap-4'>
-            <p className='text-2xl font-semibold'>김민수</p>
-            <p className='text-15 font-normal'>qug1t7@gmail.com</p>
-          </div>
+              <div className='flex flex-col justify-center gap-4'>
+                <p className='text-2xl font-semibold'>{userInfo?.nickname}</p>
+                <p className='text-15 font-normal'>{userInfo?.email}</p>
+              </div>
+            </>
+          )}
         </div>
         <div className='flex flex-col self-start w-full gap-4'>
           <p className='text-xs font-medium px-4 text-gray-500'>관리</p>

--- a/src/pages/myPage/ProfileEdit.tsx
+++ b/src/pages/myPage/ProfileEdit.tsx
@@ -5,11 +5,24 @@ import TextField from '@/components/ui/TextField';
 import { useState } from 'react';
 import DeleteModal from '@/components/ui/modal/DeleteModal';
 import clsx from 'clsx';
+import { useQuery } from '@tanstack/react-query';
+import { getUserInfo } from '@/api/users/user';
 
 const ProfileEdit = () => {
   const [nickname, setNickname] = useState('');
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const profileImage = localStorage.getItem('profileImage');
+
+  // 유저 정보 조회 API
+  const { data: userInfo, isPending } = useQuery({
+    queryKey: ['userInfo'],
+    queryFn: async () => {
+      const res = await getUserInfo();
+      if (res.error) {
+        throw new Error(res.message);
+      }
+      return res.data;
+    },
+  });
 
   const handleBlur = () => {
     console.log('blur');
@@ -39,24 +52,29 @@ const ProfileEdit = () => {
           </div>
           <div className='flex flex-col self-start w-full gap-4'>
             <p className='text-xs font-medium'>사진</p>
-            <Button
-              icon={
-                <img
-                  src={profileImage || ''}
-                  alt='profile'
-                  className='w-[96px] h-[96px] rounded-[20px]'
-                />
-              }
-              onClick={() => {
-                console.log('사진 클릭');
-              }}
-              className='cursor-pointer'
-            />
+
+            {isPending ? (
+              <div className='w-[96px] h-[96px] rounded-[20px] bg-gray-200' />
+            ) : (
+              <Button
+                icon={
+                  <img
+                    src={userInfo?.profileImage}
+                    alt='profile'
+                    className='w-[96px] h-[96px] rounded-[20px]'
+                  />
+                }
+                onClick={() => {
+                  console.log('사진 클릭');
+                }}
+                className='cursor-pointer'
+              />
+            )}
           </div>
           <div className='flex flex-col self-start w-full gap-4'>
             <TextField
               label='이름'
-              placeholder='김연수'
+              placeholder={userInfo?.nickname || ''}
               onChange={setNickname}
               onBlur={handleBlur}
               value={nickname}
@@ -65,7 +83,7 @@ const ProfileEdit = () => {
             <div className='flex flex-col gap-2'>
               <p className='text-xs'>메일</p>
               <p className='text-15 p-4 w-full rounded-[12px] py-3 border border-gray-200 bg-gray-50 text-gray'>
-                qug1t7@gmail.com
+                {userInfo?.email || '이메일'}
               </p>
             </div>
           </div>

--- a/src/pages/myPage/ProfileEdit.tsx
+++ b/src/pages/myPage/ProfileEdit.tsx
@@ -1,16 +1,20 @@
 import CommonHeader from '@/components/layout/header/CommonHeader';
-import { Button } from '@/components/common';
+import { Button, Image } from '@/components/common';
 import { isMobile } from 'react-device-detect';
 import TextField from '@/components/ui/TextField';
 import { useState } from 'react';
+
 import DeleteModal from '@/components/ui/modal/DeleteModal';
 import clsx from 'clsx';
-import { useQuery } from '@tanstack/react-query';
-import { getUserInfo } from '@/api/users/user';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getUserInfo, updateUserNickname } from '@/api/users/user';
+import toast from 'react-hot-toast';
 
 const ProfileEdit = () => {
   const [nickname, setNickname] = useState('');
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+  const queryClient = useQueryClient();
 
   // 유저 정보 조회 API
   const { data: userInfo, isPending } = useQuery({
@@ -24,8 +28,35 @@ const ProfileEdit = () => {
     },
   });
 
+  // 유저 정보 수정 API
+  const { mutate: updateUserNicknameMutation } = useMutation({
+    mutationFn: updateUserNickname,
+    onSuccess: (res) => {
+      if (res.error) {
+        toast.dismiss();
+        console.log(res.message);
+        toast.error('이름 변경에 실패했습니다');
+        return;
+      }
+      toast.dismiss();
+      toast.success('이름이 변경되었습니다');
+      queryClient.invalidateQueries({ queryKey: ['userInfo'] });
+    },
+    onError: () => {
+      toast.dismiss();
+      toast.error('이름 변경에 실패했습니다');
+    },
+  });
+
   const handleBlur = () => {
-    console.log('blur');
+    if (nickname === '') return;
+    if (nickname === userInfo?.nickname) {
+      toast.dismiss();
+      toast.error('이름이 변경되지 않았습니다');
+      return;
+    }
+    updateUserNicknameMutation(nickname);
+    setNickname('');
   };
 
   return (
@@ -56,18 +87,10 @@ const ProfileEdit = () => {
             {isPending ? (
               <div className='w-[96px] h-[96px] rounded-[20px] bg-gray-200' />
             ) : (
-              <Button
-                icon={
-                  <img
-                    src={userInfo?.profileImage}
-                    alt='profile'
-                    className='w-[96px] h-[96px] rounded-[20px]'
-                  />
-                }
-                onClick={() => {
-                  console.log('사진 클릭');
-                }}
-                className='cursor-pointer'
+              <Image
+                src={userInfo?.profileImage || ''}
+                alt='profile'
+                className='w-[96px] h-[96px] rounded-[20px]'
               />
             )}
           </div>

--- a/src/types/api/users.ts
+++ b/src/types/api/users.ts
@@ -1,0 +1,8 @@
+export interface UserInfoResponse {
+  id: number;
+  kakaoId: string;
+  email: string;
+  nickname: string;
+  profileImage: string;
+  role: string;
+}


### PR DESCRIPTION
## 📂 관련 이슈

- closes #69 

<br>

## 🔀 PR 개요

> 마이페이지, 카테고리/태그 관리 API 연결

<br>

## 📝 작업 내용

- 유저 정보 조회 API
- 유저 정보 수정 API
- MyPage에서 disable props을 zod로 관리하도록 수정]
- 카테고리/태그 관리 API

<br>

## 📸 스크린샷

https://github.com/user-attachments/assets/46f8736e-1e9f-444a-871e-4a555a85ed1c

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>
