### PR TITLE
[Feat] 계정 탈퇴 API 구현

### DIFF
--- a/src/api/users/user.ts
+++ b/src/api/users/user.ts
@@ -19,4 +19,11 @@ const updateUserNickname = async (nickname: string): Promise<ApiResponse<string>
   });
 };
 
-export { getUserInfo, updateUserNickname };
+const deleteUserInfo = async (): Promise<ApiResponse<string>> => {
+  return apiRequest<string>({
+    method: 'DELETE',
+    url: '/users/withdraw',
+  });
+};
+
+export { getUserInfo, updateUserNickname, deleteUserInfo };

--- a/src/components/ui/HomeLogo.tsx
+++ b/src/components/ui/HomeLogo.tsx
@@ -21,7 +21,7 @@ const HomLogo = () => {
       <div className='flex flex-col justify-center items-center gap-3'>
         <SymbolIcon className={clsx(isMobile ? 'w-[52px] h-[56px]' : 'w-[76px] h-[84px]')} />
         <p className={clsx('text-[#1A2033] font-semibold', isMobile ? 'text-base' : 'text-2xl')}>
-          {userInfo?.nickname ? <p>{userInfo.nickname}의 인사이트</p> : null}
+          {userInfo?.nickname ? `${userInfo.nickname}의 인사이트` : null}
         </p>
       </div>
     </div>

--- a/src/components/ui/card/FolderCard.tsx
+++ b/src/components/ui/card/FolderCard.tsx
@@ -17,6 +17,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { deleteCategory, updateCategory } from '@/api/category/category';
 import Loading from '../loading/Loading';
 import toast from 'react-hot-toast';
+import { useScrollLock } from '@/hooks/scrollLock';
 
 // 제목 텍스트 스타일 (반응형)
 const TitleText =
@@ -35,6 +36,9 @@ const FolderCard = ({
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { isMenuOpen, menuPosition, iconRef, isOpen, isClose } = useMenuHandler(); // 아이콘 기반으로 메뉴바 위치를 설정하는 커스텀 훅
   const [isDisabled, setIsDisabled] = useState(true);
+  const [isScrollLock, setIsScollLock] = useState(false);
+
+  useScrollLock(isScrollLock);
 
   const schema = modalAddSchema('category', allCategoryNames);
   const queryClient = useQueryClient();
@@ -225,6 +229,7 @@ const FolderCard = ({
             onClick={() => {
               isClose();
               setIsModalOpen(true);
+              setIsScollLock(true);
             }}
             className='text-left px-1 py-3 text-stone hover:bg-gray-100 rounded text-15'
           >
@@ -241,9 +246,11 @@ const FolderCard = ({
           setIsModalOpen(false);
           reset();
           setIsDisabled(true);
+          setIsScollLock(false);
         }}
         onConfirm={handleSubmit(handleConfirmModal)}
         disabled={isDisabled}
+        onScrollLock={false}
       >
         <Controller
           name='category'
@@ -280,7 +287,10 @@ const FolderCard = ({
       {/**삭제 모달 */}
       <DeleteModal
         isOpen={isDeleteModalOpen}
-        onCancel={() => setIsDeleteModalOpen(false)}
+        onCancel={() => {
+          setIsDeleteModalOpen(false);
+          setIsScollLock(false);
+        }}
         warningText={`"${category.categoryName}"카테고리를 정말 삭제할까요?`}
         subText={
           '카테고리를 삭제하면 해당 카테고리를 적용한 링크도 모두 삭제됩니다. 그래도 삭제할까요?'
@@ -288,7 +298,9 @@ const FolderCard = ({
         onDelete={() => {
           setIsDeleteModalOpen(false);
           deleteCategoryMutation(category.id);
+          setIsScollLock(false);
         }}
+        onScrollLock={false}
       />
     </>
   );

--- a/src/pages/myPage/ProfileEdit.tsx
+++ b/src/pages/myPage/ProfileEdit.tsx
@@ -6,14 +6,16 @@ import { useState } from 'react';
 import DeleteModal from '@/components/ui/modal/DeleteModal';
 import clsx from 'clsx';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getUserInfo, updateUserNickname } from '@/api/users/user';
+import { deleteUserInfo, getUserInfo, updateUserNickname } from '@/api/users/user';
 import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
 
 const ProfileEdit = () => {
   const [nickname, setNickname] = useState('');
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const queryClient = useQueryClient();
+  const navigate = useNavigate();
 
   // 유저 정보 조회 API
   const { data: userInfo, isPending } = useQuery({
@@ -57,6 +59,23 @@ const ProfileEdit = () => {
     updateUserNicknameMutation(nickname);
     setNickname('');
   };
+
+  const { mutate: deleteUserInfoMutation } = useMutation({
+    mutationFn: deleteUserInfo,
+    onSuccess: (res) => {
+      if (res.error) {
+        toast.dismiss();
+        toast.error('계정 삭제에 실패했습니다.');
+        return;
+      }
+      queryClient.clear(); // 모든 캐시 초기화 (로그아웃 처리)
+      navigate('/login', { replace: true });
+    },
+    onError: () => {
+      toast.dismiss();
+      toast.error('계정 삭제에 실패했습니다.');
+    },
+  });
 
   return (
     <>
@@ -131,7 +150,8 @@ const ProfileEdit = () => {
         isOpen={isDeleteModalOpen}
         onCancel={() => setIsDeleteModalOpen(false)}
         onDelete={() => {
-          console.log('계정삭제');
+          setIsDeleteModalOpen(false);
+          deleteUserInfoMutation();
         }}
         warningText='정말 계정을 삭제하시겠습니까?'
         subText='이 계정에 관련한 모든 내용은 영구삭제되며, 복구하실 수 없습니다'

--- a/src/pages/myPage/ProfileEdit.tsx
+++ b/src/pages/myPage/ProfileEdit.tsx
@@ -68,6 +68,8 @@ const ProfileEdit = () => {
         toast.error('계정 삭제에 실패했습니다.');
         return;
       }
+      toast.dismiss();
+      toast.success('계정이 삭제되었습니다.');
       queryClient.clear(); // 모든 캐시 초기화 (로그아웃 처리)
       navigate('/login', { replace: true });
     },


### PR DESCRIPTION
## 📂 관련 이슈

- closes #83 

<br>

## 🔀 PR 개요

- 계정 탈퇴 API 구현
<br>

## 📝 작업 내용

- 마이페이지에서 계정탈퇴 API를 구현
  - 계정 탈퇴시 바로 로그인 창으로 이동되는게 적용이 안 돼서 일단 계정 탈퇴 성공시 이동하도록 해두었음

<br>

## 📸 스크린샷


https://github.com/user-attachments/assets/77998d21-12e6-432c-a874-d05751ed9f44


<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>

## 🔧 추가 사항

> 

<br>
