### PR TITLE
[Feat] #93 CompactCard 및 Alarm 디자인 반영

### DIFF
--- a/src/components/ui/card/CompactCard.tsx
+++ b/src/components/ui/card/CompactCard.tsx
@@ -6,7 +6,16 @@ import DeleteModal from '../modal/DeleteModal';
 import { useMenuHandler } from '@/hooks/menuPosition';
 import { useEffect, useRef, useState } from 'react';
 
-const CompactCard = ({ title, image, memo, category, tags, isNotified }: CompactCardProps) => {
+const CompactCard = ({
+  title,
+  image,
+  memo,
+  category,
+  tags,
+  isNotified,
+  platform,
+  faviconUrl,
+}: CompactCardProps) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { isMenuOpen, menuPosition, iconRef, isOpen, isClose } = useMenuHandler();
   const tagContainerRef = useRef<HTMLDivElement>(null);
@@ -48,7 +57,7 @@ const CompactCard = ({ title, image, memo, category, tags, isNotified }: Compact
               </p>
               <div
                 ref={tagContainerRef}
-                className='relative flex flex-row gap-2 overflow-hidden min-w-0'
+                className='relative flex flex-row gap-2 overflow-hidden min-w-0 items-center'
               >
                 {tags.map((tag, index) => (
                   <p
@@ -58,6 +67,10 @@ const CompactCard = ({ title, image, memo, category, tags, isNotified }: Compact
                     {tag}
                   </p>
                 ))}
+                <div className='flex flex-row items-center gap-1 bg-snowGray rounded-lg px-2 py-1 '>
+                  {faviconUrl && <img src={faviconUrl} alt='favicon' className='w-3 h-3' />}
+                  <p className='text-[10px] text-darkGray font-medium flex-shrink-0'>{platform}</p>
+                </div>
                 {isOverflow && (
                   <div className='pointer-events-none absolute right-0 top-0 h-full w-8 bg-gradient-to-l from-white/80 to-transparent' />
                 )}

--- a/src/components/ui/card/CompactCard.tsx
+++ b/src/components/ui/card/CompactCard.tsx
@@ -6,7 +6,7 @@ import DeleteModal from '../modal/DeleteModal';
 import { useMenuHandler } from '@/hooks/menuPosition';
 import { useEffect, useRef, useState } from 'react';
 
-const CompactCard = ({ title, image, memo, category, tags }: CompactCardProps) => {
+const CompactCard = ({ title, image, memo, category, tags, isNotified }: CompactCardProps) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { isMenuOpen, menuPosition, iconRef, isOpen, isClose } = useMenuHandler();
   const tagContainerRef = useRef<HTMLDivElement>(null);
@@ -30,7 +30,9 @@ const CompactCard = ({ title, image, memo, category, tags }: CompactCardProps) =
             className='absolute inset-0 w-full h-full object-cover rounded-lg'
             onClick={() => console.log('Image clicked')}
           />
-          <AlertIcon width={16} height={16} stroke='white' className='absolute top-1 right-1' />
+          {isNotified && (
+            <AlertIcon width={16} height={16} stroke='white' className='absolute top-1 right-1' />
+          )}
         </div>
         <div className='flex flex-col gap-2 justify-between w-full min-w-0'>
           <p className='text-sm sm:text-base font-semibold whitespace-nowrap overflow-hidden text-ellipsis'>

--- a/src/components/ui/card/CompactCard.tsx
+++ b/src/components/ui/card/CompactCard.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from 'react';
 
 const CompactCard = ({
   title,
+  url,
   image,
   memo,
   category,
@@ -37,7 +38,7 @@ const CompactCard = ({
             src={image}
             alt='CompactCard'
             className='absolute inset-0 w-full h-full object-cover rounded-lg'
-            onClick={() => console.log('Image clicked')}
+            onClick={() => window.open(url, '_blank')}
           />
           {isNotified && (
             <AlertIcon width={16} height={16} stroke='white' className='absolute top-1 right-1' />

--- a/src/components/ui/card/SaveCard.tsx
+++ b/src/components/ui/card/SaveCard.tsx
@@ -10,27 +10,15 @@ import DeleteModal from '../modal/DeleteModal';
 import { useEffect, useRef, useState } from 'react';
 import dayjs from 'dayjs';
 import type { BookmarkProps } from '@/types/components/components';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteBookmarks } from '@/api/bookmark/bookmark';
 import toast from 'react-hot-toast';
-import { getNotificaton } from '@/api/alarm/notification';
 
 const SaveCard = ({ data }: { data: BookmarkProps }) => {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const { isMenuOpen, menuPosition, iconRef, isOpen, isClose } = useMenuHandler();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-
-  const { data: notificationData } = useQuery({
-    queryKey: ['notification'],
-    queryFn: async () => {
-      const res = await getNotificaton(data.id);
-      if (res.error) {
-        throw new Error(res.message);
-      }
-      return res.data;
-    },
-  });
 
   const deleteBookmarkMutate = useMutation({
     mutationFn: deleteBookmarks,
@@ -42,8 +30,6 @@ const SaveCard = ({ data }: { data: BookmarkProps }) => {
       toast.error('북마크 삭제에 실패했습니다');
     },
   });
-
-  const isNotified = notificationData?.some((noti) => noti.isNotified) ?? false;
 
   const x = useMotionValue(0);
   const dragRef = useRef<HTMLDivElement>(null);
@@ -153,7 +139,7 @@ const SaveCard = ({ data }: { data: BookmarkProps }) => {
                   <p className='text-sm text-stone'>
                     {dayjs(data.createdAt).format('YYYY.MM.DD HH:mm')} 저장
                   </p>
-                  {isNotified && <AlertIcon width={16} height={16} stroke={'#A4A8B2'} />}
+                  {data.isNotified && <AlertIcon width={16} height={16} stroke={'#A4A8B2'} />}
                 </div>
                 <div ref={iconRef} onClick={isOpen}>
                   <FolderDetailIcon

--- a/src/components/ui/cardList/SaveCardList.tsx
+++ b/src/components/ui/cardList/SaveCardList.tsx
@@ -47,6 +47,7 @@ const SaveCardList = () => {
         tags,
         faviconUrl: data.faviconUrl,
         createdAt: data.createdAt,
+        isNotified: data.notificationResponse?.isNotified ?? false,
       };
     });
 

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -271,6 +271,7 @@ const SearchResult = () => {
                   memo={bookmark.memo}
                   category={bookmark.categoryTagInfos[0].categoryName}
                   tags={bookmark.categoryTagInfos[0].tags.map((tag) => tag.tagName)}
+                  isNotified={bookmark.notificationResponse?.isNotified ?? false}
                 />
               ))
             ) : (
@@ -289,6 +290,7 @@ const SearchResult = () => {
                       category: bookmark.categoryTagInfos[0].categoryName,
                       tags: bookmark.categoryTagInfos[0].tags.map((tag) => tag.tagName),
                       createdAt: bookmark.createdAt,
+                      isNotified: bookmark.notificationResponse?.isNotified ?? false,
                     }}
                   />
                 ))}

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -267,6 +267,7 @@ const SearchResult = () => {
                   key={bookmark.id}
                   id={bookmark.id}
                   title={bookmark.title}
+                  url={bookmark.url}
                   image={bookmark.file.fileUrl}
                   memo={bookmark.memo}
                   category={bookmark.categoryTagInfos[0].categoryName}

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -271,6 +271,8 @@ const SearchResult = () => {
                   memo={bookmark.memo}
                   category={bookmark.categoryTagInfos[0].categoryName}
                   tags={bookmark.categoryTagInfos[0].tags.map((tag) => tag.tagName)}
+                  platform={bookmark.platform}
+                  faviconUrl={bookmark.faviconUrl}
                   isNotified={bookmark.notificationResponse?.isNotified ?? false}
                 />
               ))

--- a/src/types/components/components.ts
+++ b/src/types/components/components.ts
@@ -28,6 +28,8 @@ export interface CompactCardProps {
   memo: string;
   category: string;
   tags: string[];
+  platform: string;
+  faviconUrl: string;
   isNotified: boolean;
 }
 

--- a/src/types/components/components.ts
+++ b/src/types/components/components.ts
@@ -9,6 +9,7 @@ export interface BookmarkProps {
   category: string;
   tags: string[];
   createdAt: string;
+  isNotified: boolean;
 }
 
 export interface ChipProps {
@@ -27,6 +28,7 @@ export interface CompactCardProps {
   memo: string;
   category: string;
   tags: string[];
+  isNotified: boolean;
 }
 
 export interface CategoryCardProps {

--- a/src/types/components/components.ts
+++ b/src/types/components/components.ts
@@ -24,6 +24,7 @@ export interface ChipProps {
 export interface CompactCardProps {
   id: number;
   title: string;
+  url: string;
   image: string;
   memo: string;
   category: string;


### PR DESCRIPTION
## 📂 관련 이슈

- closes #93 

<br>

## 🔀 PR 개요

> CompactCard 및 Alarm 디자인 반영

<br>

## 📝 작업 내용

- Card에 Alarm 디자인 추가
- Compact Card에 플랫폼 디자인 추가
- Compact Card 이미지 클릭 시 저장된 링크로 이동 되도록 구현

<br>

## 📸 스크린샷
<img width="176" height="29" alt="image" src="https://github.com/user-attachments/assets/b77df276-14d1-4c4f-9875-e4f6ee06ebdb" />

- 알람은 지금 현재 구현되지 않아, 후에 알람 기능 추가 시에 디자인 확인 가능
<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>