### PR TITLE
[Fix] #97 카카오 로그인 오류 및 경로 오류 해결

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -12,6 +12,7 @@ import {
   ProfileEdit,
   CategoryManagement,
   Inquiry,
+  Error,
 } from '@/pages';
 import App from '@/App';
 
@@ -105,6 +106,10 @@ const router = createBrowserRouter([
   {
     path: '/auth/login/kakao',
     element: <KakaoCallBack />,
+  },
+  {
+    path: '*',
+    element: <Error />,
   },
 ]);
 

--- a/src/api/auth/auth_api.ts
+++ b/src/api/auth/auth_api.ts
@@ -19,10 +19,16 @@ const kakaoLogin = async () => {
 };
 
 const kakaoLoginApi = async (code: string): Promise<ApiResponse<KakaoLoginResponse>> => {
+  const currentOrigin = window.location.origin;
+  const fullRedirectUri = `${currentOrigin}/${KAKAO_REDIRECT_URI} 123`;
+
   return apiRequest<KakaoLoginResponse>({
     method: 'GET',
     url: '/auth/login/kakao',
-    params: { code },
+    params: {
+      code: code,
+      redirectUri: fullRedirectUri,
+    },
   });
 };
 

--- a/src/api/auth/auth_api.ts
+++ b/src/api/auth/auth_api.ts
@@ -20,7 +20,7 @@ const kakaoLogin = async () => {
 
 const kakaoLoginApi = async (code: string): Promise<ApiResponse<KakaoLoginResponse>> => {
   const currentOrigin = window.location.origin;
-  const fullRedirectUri = `${currentOrigin}/${KAKAO_REDIRECT_URI} 123`;
+  const fullRedirectUri = `${currentOrigin}/${KAKAO_REDIRECT_URI}`;
 
   return apiRequest<KakaoLoginResponse>({
     method: 'GET',

--- a/src/pages/Error.tsx
+++ b/src/pages/Error.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from 'react';
+import toast from 'react-hot-toast';
+import { useNavigate } from 'react-router-dom';
+
+const Error = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    toast.dismiss();
+    toast.error('잘못된 접근입니다.');
+    navigate('/');
+  }, [navigate]);
+
+  return <div>Error</div>;
+};
+
+export default Error;

--- a/src/pages/KakaoCallBack.tsx
+++ b/src/pages/KakaoCallBack.tsx
@@ -23,6 +23,7 @@ function KakaoCallBack() {
       if (res.error) {
         console.error('kakao login 실패, error', res.message);
         toast.error('로그인 실패');
+        // 토스트가 표시될 시간을 주기 위해 약간의 지연 추가
         navigate('/login', { replace: true });
         return;
       }
@@ -37,6 +38,7 @@ function KakaoCallBack() {
     onError: (error) => {
       console.error('kakao login 실패, error', error);
       toast.error('로그인 실패');
+      // 토스트가 표시될 시간을 주기 위해 약간의 지연 추가
       navigate('/login', { replace: true });
     },
   });

--- a/src/pages/KakaoCallBack.tsx
+++ b/src/pages/KakaoCallBack.tsx
@@ -23,7 +23,6 @@ function KakaoCallBack() {
       if (res.error) {
         console.error('kakao login 실패, error', res.message);
         toast.error('로그인 실패');
-        // 토스트가 표시될 시간을 주기 위해 약간의 지연 추가
         navigate('/login', { replace: true });
         return;
       }
@@ -38,7 +37,6 @@ function KakaoCallBack() {
     onError: (error) => {
       console.error('kakao login 실패, error', error);
       toast.error('로그인 실패');
-      // 토스트가 표시될 시간을 주기 위해 약간의 지연 추가
       navigate('/login', { replace: true });
     },
   });

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import Button from '@/components/common/Button';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import { motion } from 'framer-motion';
+import Toast from '@/components/common/Toast';
 
 const Login = () => {
   const navigate = useNavigate();
@@ -87,6 +88,7 @@ const Login = () => {
         </div>
       </div>
       <div className='absolute bottom-0 left-0 w-full h-70 bg-gradient-to-t from-blue-200 to-transparent pointer-events-none' />
+      <Toast />
     </div>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,6 +10,7 @@ import MyPage from './myPage/MyPage';
 import ProfileEdit from './myPage/ProfileEdit';
 import CategoryManagement from './myPage/CategoryManagement';
 import Inquiry from './myPage/Inquiry';
+import Error from './Error';
 
 export {
   Home,
@@ -24,4 +25,5 @@ export {
   ProfileEdit,
   CategoryManagement,
   Inquiry,
+  Error,
 };


### PR DESCRIPTION
## 📂 관련 이슈

- closes #97 

<br>

## 🔀 PR 개요

> 카카오 로그인 오류 및 경로 오류 해결

<br>

## 📝 작업 내용

- 카카오 로그인 관련 api 수정
- 로그인 실패 시 toast가 올바르게 뜨도록 수정
- 경로 오류 해결

<br>

## 📸 스크린샷

<img width="603" height="567" alt="image" src="https://github.com/user-attachments/assets/e5a3c248-3e95-4922-a375-501a75e8beff" />

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과
