### PR TITLE
[Fix] #99 Page에서 발생되는 여러 오류 수정

### DIFF
--- a/src/components/layout/header/ProfileHeader.tsx
+++ b/src/components/layout/header/ProfileHeader.tsx
@@ -31,9 +31,9 @@ const ProfileHeader = () => {
               onClick={() => {
                 const currentHash = window.location.hash;
                 if (isMobile) {
-                  navigate(`./my-page${currentHash}`);
+                  navigate(`./my-page${currentHash}`, { replace: true });
                 } else {
-                  navigate(`./my-page/profile-edit${currentHash}`);
+                  navigate(`./my-page/profile-edit${currentHash}`, { replace: true });
                 }
               }}
               className='cursor-pointer'

--- a/src/components/layout/header/ProfileHeader.tsx
+++ b/src/components/layout/header/ProfileHeader.tsx
@@ -29,10 +29,11 @@ const ProfileHeader = () => {
                 />
               }
               onClick={() => {
+                const currentHash = window.location.hash;
                 if (isMobile) {
-                  navigate('./my-page');
+                  navigate(`./my-page${currentHash}`);
                 } else {
-                  navigate('./my-page/profile-edit');
+                  navigate(`./my-page/profile-edit${currentHash}`);
                 }
               }}
               className='cursor-pointer'

--- a/src/components/ui/card/CategoryCard.tsx
+++ b/src/components/ui/card/CategoryCard.tsx
@@ -58,11 +58,6 @@ const CategoryCard = ({
   const { mutate: updateCategoryMutation } = useMutation({
     mutationFn: (categoryName: string) => updateCategory(categoryId, categoryName),
     onMutate: async (newCategoryName) => {
-      // 검색 결과 페이지에서 카테고리 수정 시 검색 결과 다시 불러오기
-      if (window.location.pathname.includes('search-result')) {
-        window.dispatchEvent(new Event('bookmarkChanged'));
-      }
-
       // 진행 중인 쿼리 취소
       await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
 
@@ -95,17 +90,17 @@ const CategoryCard = ({
 
       toast.success('카테고리 수정 완료');
       queryClient.invalidateQueries({ queryKey: ['categoriesWithTags'] });
+
+      // 검색 결과 페이지에서 카테고리 수정 시 검색 결과 다시 불러오기
+      if (window.location.pathname.includes('search-result')) {
+        window.dispatchEvent(new Event('bookmarkChanged'));
+      }
     },
   });
 
   const { mutate: deleteCategoryMutation } = useMutation({
     mutationFn: (categoryId: number) => deleteCategory(categoryId),
     onMutate: async (categoryId) => {
-      // 검색 결과 페이지에서 카테고리 수정 시 검색 결과 다시 불러오기
-      if (window.location.pathname.includes('search-result')) {
-        window.dispatchEvent(new Event('bookmarkChanged'));
-      }
-
       await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
       const previousCategories = queryClient.getQueryData(['categoriesWithTags']);
       queryClient.setQueryData(['categoriesWithTags'], (old: any) => {
@@ -129,6 +124,11 @@ const CategoryCard = ({
 
       toast.success('카테고리 삭제 완료');
       queryClient.invalidateQueries({ queryKey: ['categoriesWithTags'] });
+
+      // 검색 결과 페이지에서 카테고리 수정 시 검색 결과 다시 불러오기
+      if (window.location.pathname.includes('search-result')) {
+        window.dispatchEvent(new Event('bookmarkChanged'));
+      }
     },
   });
 

--- a/src/components/ui/card/CategoryCard.tsx
+++ b/src/components/ui/card/CategoryCard.tsx
@@ -58,6 +58,11 @@ const CategoryCard = ({
   const { mutate: updateCategoryMutation } = useMutation({
     mutationFn: (categoryName: string) => updateCategory(categoryId, categoryName),
     onMutate: async (newCategoryName) => {
+      // 검색 결과 페이지에서 카테고리 수정 시 검색 결과 다시 불러오기
+      if (window.location.pathname.includes('search-result')) {
+        window.dispatchEvent(new Event('bookmarkChanged'));
+      }
+
       // 진행 중인 쿼리 취소
       await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
 
@@ -96,6 +101,11 @@ const CategoryCard = ({
   const { mutate: deleteCategoryMutation } = useMutation({
     mutationFn: (categoryId: number) => deleteCategory(categoryId),
     onMutate: async (categoryId) => {
+      // 검색 결과 페이지에서 카테고리 수정 시 검색 결과 다시 불러오기
+      if (window.location.pathname.includes('search-result')) {
+        window.dispatchEvent(new Event('bookmarkChanged'));
+      }
+
       await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
       const previousCategories = queryClient.getQueryData(['categoriesWithTags']);
       queryClient.setQueryData(['categoriesWithTags'], (old: any) => {

--- a/src/components/ui/card/CompactCard.tsx
+++ b/src/components/ui/card/CompactCard.tsx
@@ -117,7 +117,8 @@ const CompactCard = ({
           <Button
             onClick={() => {
               isClose();
-              navigate(`edit/${id}`);
+              const currentHash = window.location.hash;
+              navigate(`edit/${id}${currentHash}`);
             }}
             className='text-left px-1 py-3 text-stone hover:bg-gray-100 rounded text-15 cursor-pointer'
           >

--- a/src/components/ui/card/CompactCard.tsx
+++ b/src/components/ui/card/CompactCard.tsx
@@ -33,7 +33,7 @@ const CompactCard = ({
     mutationFn: deleteBookmarks,
     onSuccess: () => {
       // 북마크 삭제 이벤트 발생 (SearchResult에서 검색 다시 실행)
-      window.dispatchEvent(new Event('bookmarkDeleted'));
+      window.dispatchEvent(new Event('bookmarkChanged'));
       toast.success('북마크 삭제에 성공했습니다');
     },
     onError: () => {

--- a/src/components/ui/card/SaveCard.tsx
+++ b/src/components/ui/card/SaveCard.tsx
@@ -25,7 +25,7 @@ const SaveCard = ({ data, type = 'home' }: { data: BookmarkProps; type?: 'search
     onSuccess: () => {
       // 북마크 조회 이벤트
       if (type === 'search') {
-        window.dispatchEvent(new Event('bookmarkDeleted'));
+        window.dispatchEvent(new Event('bookmarkChanged'));
       } else {
         queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
       }

--- a/src/components/ui/card/SaveCard.tsx
+++ b/src/components/ui/card/SaveCard.tsx
@@ -168,7 +168,8 @@ const SaveCard = ({ data, type = 'home' }: { data: BookmarkProps; type?: 'search
           <Button
             onClick={() => {
               isClose();
-              navigate(`edit/${data.id}`);
+              const currentHash = window.location.hash;
+              navigate(`edit/${data.id}${currentHash}`);
             }}
             className='text-left px-1 py-3 text-stone hover:bg-gray-100 rounded text-15 cursor-pointer'
           >

--- a/src/components/ui/chip/TagSettingChip.tsx
+++ b/src/components/ui/chip/TagSettingChip.tsx
@@ -39,11 +39,6 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
   const { mutate: updateTagMutation } = useMutation({
     mutationFn: (tagName: string) => updateTag(tagId, tagName),
     onMutate: async (newTagName) => {
-      // 검색 결과 페이지에서 태그 수정 시 검색 결과 다시 불러오기
-      if (window.location.pathname.includes('search-result')) {
-        window.dispatchEvent(new Event('bookmarkChanged'));
-      }
-
       // 진행 중인 쿼리 취소
       await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
 
@@ -85,17 +80,17 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
 
       toast.success('태그 수정 완료');
       queryClient.invalidateQueries({ queryKey: ['categoriesWithTags'] });
+
+      // 검색 결과 페이지에서 태그 수정 시 검색 결과 다시 불러오기
+      if (window.location.pathname.includes('search-result')) {
+        window.dispatchEvent(new Event('bookmarkChanged'));
+      }
     },
   });
 
   const { mutate: deleteTagMutation } = useMutation({
     mutationFn: (tagId: number) => deleteTag(tagId),
     onMutate: async (tagId) => {
-      // 검색 결과 페이지에서 태그 삭제 시 검색 결과 다시 불러오기
-      if (window.location.pathname.includes('search-result')) {
-        window.dispatchEvent(new Event('bookmarkChanged'));
-      }
-
       await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
       const previousCategories = queryClient.getQueryData(['categoriesWithTags']);
       queryClient.setQueryData(['categoriesWithTags'], (old: any) => {
@@ -122,6 +117,11 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
 
       toast.success('태그 삭제 완료');
       queryClient.invalidateQueries({ queryKey: ['categoriesWithTags'] });
+
+      // 검색 결과 페이지에서 태그 삭제 시 검색 결과 다시 불러오기
+      if (window.location.pathname.includes('search-result')) {
+        window.dispatchEvent(new Event('bookmarkChanged'));
+      }
     },
   });
 

--- a/src/components/ui/chip/TagSettingChip.tsx
+++ b/src/components/ui/chip/TagSettingChip.tsx
@@ -39,6 +39,11 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
   const { mutate: updateTagMutation } = useMutation({
     mutationFn: (tagName: string) => updateTag(tagId, tagName),
     onMutate: async (newTagName) => {
+      // 검색 결과 페이지에서 태그 수정 시 검색 결과 다시 불러오기
+      if (window.location.pathname.includes('search-result')) {
+        window.dispatchEvent(new Event('bookmarkChanged'));
+      }
+
       // 진행 중인 쿼리 취소
       await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
 
@@ -86,6 +91,11 @@ const TagSettingChip = ({ tagId, tagName, allTagNames }: TagSettingChipProps) =>
   const { mutate: deleteTagMutation } = useMutation({
     mutationFn: (tagId: number) => deleteTag(tagId),
     onMutate: async (tagId) => {
+      // 검색 결과 페이지에서 태그 삭제 시 검색 결과 다시 불러오기
+      if (window.location.pathname.includes('search-result')) {
+        window.dispatchEvent(new Event('bookmarkChanged'));
+      }
+
       await queryClient.cancelQueries({ queryKey: ['categoriesWithTags'] });
       const previousCategories = queryClient.getQueryData(['categoriesWithTags']);
       queryClient.setQueryData(['categoriesWithTags'], (old: any) => {

--- a/src/hooks/ensureHttps.ts
+++ b/src/hooks/ensureHttps.ts
@@ -1,0 +1,8 @@
+function ensureHttps(url: string): string {
+  if (url.startsWith('http://')) {
+    return url.replace('http://', 'https://');
+  }
+  return url;
+}
+
+export default ensureHttps;

--- a/src/pages/KakaoCallBack.tsx
+++ b/src/pages/KakaoCallBack.tsx
@@ -6,6 +6,7 @@ import { isMobile } from 'react-device-detect';
 import Lottie from 'lottie-react';
 import logoAnimation from '@/assets/logoAnimation.json';
 import toast from 'react-hot-toast';
+import ensureHttps from '@/hooks/ensureHttps';
 
 function KakaoCallBack() {
   const navigate = useNavigate();
@@ -30,7 +31,7 @@ function KakaoCallBack() {
       const { jwtAccessToken, jwtRefreshToken, profileImage } = res.data;
       localStorage.setItem('accessToken', jwtAccessToken);
       localStorage.setItem('refreshToken', jwtRefreshToken);
-      localStorage.setItem('profileImage', profileImage);
+      localStorage.setItem('profileImage', ensureHttps(profileImage));
       toast.success('로그인 성공');
       navigate('/', { replace: true });
     },

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -118,8 +118,6 @@ const SearchResult = () => {
       size: 9999,
     };
 
-    console.log(requestData);
-
     // POST 요청 보내기
     BookmarkSearchResultMutation(requestData);
   };
@@ -134,7 +132,6 @@ const SearchResult = () => {
     setIsInitialized(false);
 
     const hash = window.location.hash.slice(1);
-    console.log(hash);
     if (hash) {
       const decoded = atob(hash);
       const queryData = JSON.parse(decodeURIComponent(decoded));
@@ -170,10 +167,7 @@ const SearchResult = () => {
   // 파라미터가 변경될 때마다 검색 실행 + 북마크 삭제 후 검색 결과 다시 불러오기
   useEffect(() => {
     // 초기화가 완료된 후에만 검색 실행
-    if (isInitialized) {
-      getBookmarkSearchResult();
-      console.log('execute');
-    }
+    if (isInitialized) getBookmarkSearchResult();
 
     // 북마크 삭제 이벤트 리스너 등록
     const handleBookmarkDeleted = () => {

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -1,7 +1,7 @@
 import CompactCard from '@/components/ui/card/CompactCard';
 import ChipDropDown from '@/components/layout/dropDown/ChipDropDown';
 import ChangeSearchBar from '@/components/layout/searchBar/ChangeSearchBar';
-import { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import type { ChipProps } from '@/types/components/components';
 import clsx from 'clsx';
 import { isMobile } from 'react-device-detect';
@@ -33,6 +33,9 @@ const SearchResult = () => {
   const [paramsCategories, setParamsCategories] = useState<SearchCategory[]>([]);
   const [paramsTags, setParamsTags] = useState<SearchTag[]>([]);
   const [paramsPlatforms, setParamsPlatforms] = useState<PlatformProps[]>([]);
+
+  // 초기 로드 여부를 추적하는 상태
+  const [isInitialized, setIsInitialized] = useState(false);
 
   // 검색 결과
   const [bookmarks, setBookmarks] = useState<BookmarkSearchResultProps['content']>([]);
@@ -88,7 +91,7 @@ const SearchResult = () => {
     window.scrollTo({ top: 0, behavior: 'auto' });
   }, []);
 
-  const getBookmarkSearchResult = useCallback(() => {
+  const getBookmarkSearchResult = () => {
     const categoryTagRequests = paramsCategories.map((category) => {
       // selectedTags에서 categoryId가 categoryIds 배열에 포함된 태그만 필터링
       const tagList = paramsTags
@@ -115,14 +118,23 @@ const SearchResult = () => {
       size: 9999,
     };
 
+    console.log(requestData);
+
     // POST 요청 보내기
     BookmarkSearchResultMutation(requestData);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [paramsCategories, paramsTags, paramsPlatforms, searchContents]);
+  };
 
   // URL 파라미터에서 값을 가져와서 atom에 설정
   useEffect(() => {
+    // hash가 변경될 때마다 파라미터들을 먼저 초기화
+    setSearchContents('');
+    setParamsCategories([]);
+    setParamsTags([]);
+    setParamsPlatforms([]);
+    setIsInitialized(false);
+
     const hash = window.location.hash.slice(1);
+    console.log(hash);
     if (hash) {
       const decoded = atob(hash);
       const queryData = JSON.parse(decodeURIComponent(decoded));
@@ -144,30 +156,24 @@ const SearchResult = () => {
         if (platformsParam) {
           setParamsPlatforms(platformsParam);
         }
+        setIsInitialized(true);
       } catch (error) {
         toast.error('검색 결과를 불러오는데 실패했습니다.');
         console.error('URL 파라미터 파싱 에러:', error);
         navigate('/', { replace: true });
       }
     } else {
-      setSearchContents('');
-      setParamsCategories([]);
-      setParamsTags([]);
-      setParamsPlatforms([]);
+      setIsInitialized(true);
     }
-  }, [
-    location.hash,
-    navigate,
-    setSearchContents,
-    setParamsCategories,
-    setParamsTags,
-    setParamsPlatforms,
-  ]);
+  }, [location.hash, navigate]);
 
   // 파라미터가 변경될 때마다 검색 실행 + 북마크 삭제 후 검색 결과 다시 불러오기
   useEffect(() => {
-    // 파라미터 변경 시 검색 실행
-    getBookmarkSearchResult();
+    // 초기화가 완료된 후에만 검색 실행
+    if (isInitialized) {
+      getBookmarkSearchResult();
+      console.log('execute');
+    }
 
     // 북마크 삭제 이벤트 리스너 등록
     const handleBookmarkDeleted = () => {
@@ -179,7 +185,9 @@ const SearchResult = () => {
     return () => {
       window.removeEventListener('bookmarkDeleted', handleBookmarkDeleted);
     };
-  }, [getBookmarkSearchResult]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paramsCategories, paramsTags, paramsPlatforms, searchContents, isInitialized]);
 
   // searchResultData가 변경될 때만 searchResult 업데이트
   useEffect(() => {

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -37,6 +37,9 @@ const SearchResult = () => {
   // 초기 로드 여부를 추적하는 상태
   const [isInitialized, setIsInitialized] = useState(false);
 
+  // 강제 새로고침을 위한 키
+  const [refreshKey, setRefreshKey] = useState(0);
+
   // 검색 결과
   const [bookmarks, setBookmarks] = useState<BookmarkSearchResultProps['content']>([]);
 
@@ -73,7 +76,7 @@ const SearchResult = () => {
     isPending,
     data: searchResult,
   } = useMutation({
-    mutationKey: ['bookmarkSearchResult'],
+    mutationKey: ['bookmarkSearchResult', refreshKey],
     mutationFn: postBookmarkSearchResult,
     onError: (error) => {
       console.error('검색 에러:', error);
@@ -171,6 +174,8 @@ const SearchResult = () => {
 
     // 북마크 변경 이벤트 리스너 등록
     const handleBookmarkChanged = () => {
+      // 강제 새로고침을 위해 refreshKey 업데이트
+      setRefreshKey((prev) => prev + 1);
       getBookmarkSearchResult();
     };
 
@@ -181,7 +186,7 @@ const SearchResult = () => {
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [paramsCategories, paramsTags, paramsPlatforms, searchContents, isInitialized]);
+  }, [paramsCategories, paramsTags, paramsPlatforms, searchContents, isInitialized, refreshKey]);
 
   // searchResultData가 변경될 때만 searchResult 업데이트
   useEffect(() => {

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -169,15 +169,15 @@ const SearchResult = () => {
     // 초기화가 완료된 후에만 검색 실행
     if (isInitialized) getBookmarkSearchResult();
 
-    // 북마크 삭제 이벤트 리스너 등록
-    const handleBookmarkDeleted = () => {
+    // 북마크 변경 이벤트 리스너 등록
+    const handleBookmarkChanged = () => {
       getBookmarkSearchResult();
     };
 
-    window.addEventListener('bookmarkDeleted', handleBookmarkDeleted);
+    window.addEventListener('bookmarkChanged', handleBookmarkChanged);
 
     return () => {
-      window.removeEventListener('bookmarkDeleted', handleBookmarkDeleted);
+      window.removeEventListener('bookmarkChanged', handleBookmarkChanged);
     };
 
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/pages/myPage/Container.tsx
+++ b/src/pages/myPage/Container.tsx
@@ -62,7 +62,10 @@ const MyPage = () => {
   return (
     <div
       className={overlayStyle({ isMobile })}
-      onClick={() => navigate(isSearchResult ? '/search-result' : '/')}
+      onClick={() => {
+        const currentHash = window.location.hash;
+        navigate(isSearchResult ? `/search-result${currentHash}` : `/`);
+      }}
     >
       <div className={modalStyle({ isMobile })} onClick={(e) => e.stopPropagation()}>
         {isMobile ? (

--- a/src/pages/myPage/Container.tsx
+++ b/src/pages/myPage/Container.tsx
@@ -61,11 +61,12 @@ const MyPage = () => {
 
   const currentHash = window.location.hash;
 
+  const handleClose = () => {
+    navigate(isSearchResult ? `/search-result${currentHash}` : `/`, { replace: true });
+  };
+
   return (
-    <div
-      className={overlayStyle({ isMobile })}
-      onClick={() => navigate(isSearchResult ? `/search-result${currentHash}` : `/`)}
-    >
+    <div className={overlayStyle({ isMobile })} onClick={handleClose}>
       <div className={modalStyle({ isMobile })} onClick={(e) => e.stopPropagation()}>
         {isMobile ? (
           // 모바일: 전체 화면
@@ -84,7 +85,7 @@ const MyPage = () => {
                     'text-left p-3 rounded-lg transition-colors text-stone',
                     isProfileEdit ? 'bg-grayBg' : 'hover:bg-gray-100',
                   )}
-                  onClick={() => navigate(`./profile-edit${currentHash}`)}
+                  onClick={() => navigate(`./profile-edit${currentHash}`, { replace: true })}
                 >
                   프로필 수정
                 </Button>
@@ -94,7 +95,7 @@ const MyPage = () => {
                     'text-left p-3 rounded-lg transition-colors text-stone',
                     isCategoryManagement ? 'bg-grayBg' : 'hover:bg-gray-100',
                   )}
-                  onClick={() => navigate(`./category-management${currentHash}`)}
+                  onClick={() => navigate(`./category-management${currentHash}`, { replace: true })}
                 >
                   카테고리 / 태그 관리
                 </Button>
@@ -104,7 +105,7 @@ const MyPage = () => {
                     'text-left p-3 rounded-lg transition-colors text-stone',
                     isInquiry ? 'bg-grayBg' : 'hover:bg-gray-100',
                   )}
-                  onClick={() => navigate(`./inquiry${currentHash}`)}
+                  onClick={() => navigate(`./inquiry${currentHash}`, { replace: true })}
                 >
                   문의하기
                 </Button>
@@ -130,7 +131,7 @@ const MyPage = () => {
             <div className='absolute top-10 right-10'>
               <Button
                 icon={<DeleteIcon width={12} height={12} stroke='#000000' />}
-                onClick={() => navigate(isSearchResult ? '/search-result' : '/')}
+                onClick={handleClose}
                 className='cursor-pointer'
               />
             </div>

--- a/src/pages/myPage/Container.tsx
+++ b/src/pages/myPage/Container.tsx
@@ -59,13 +59,12 @@ const MyPage = () => {
     navigate('/login');
   };
 
+  const currentHash = window.location.hash;
+
   return (
     <div
       className={overlayStyle({ isMobile })}
-      onClick={() => {
-        const currentHash = window.location.hash;
-        navigate(isSearchResult ? `/search-result${currentHash}` : `/`);
-      }}
+      onClick={() => navigate(isSearchResult ? `/search-result${currentHash}` : `/`)}
     >
       <div className={modalStyle({ isMobile })} onClick={(e) => e.stopPropagation()}>
         {isMobile ? (
@@ -85,7 +84,7 @@ const MyPage = () => {
                     'text-left p-3 rounded-lg transition-colors text-stone',
                     isProfileEdit ? 'bg-grayBg' : 'hover:bg-gray-100',
                   )}
-                  onClick={() => navigate('./profile-edit')}
+                  onClick={() => navigate(`./profile-edit${currentHash}`)}
                 >
                   프로필 수정
                 </Button>
@@ -95,7 +94,7 @@ const MyPage = () => {
                     'text-left p-3 rounded-lg transition-colors text-stone',
                     isCategoryManagement ? 'bg-grayBg' : 'hover:bg-gray-100',
                   )}
-                  onClick={() => navigate('./category-management')}
+                  onClick={() => navigate(`./category-management${currentHash}`)}
                 >
                   카테고리 / 태그 관리
                 </Button>
@@ -105,7 +104,7 @@ const MyPage = () => {
                     'text-left p-3 rounded-lg transition-colors text-stone',
                     isInquiry ? 'bg-grayBg' : 'hover:bg-gray-100',
                   )}
-                  onClick={() => navigate('./inquiry')}
+                  onClick={() => navigate(`./inquiry${currentHash}`)}
                 >
                   문의하기
                 </Button>

--- a/src/pages/myPage/Inquiry.tsx
+++ b/src/pages/myPage/Inquiry.tsx
@@ -11,7 +11,7 @@ const Inquiry = () => {
   // 모바일은 접근 불가
   useEffect(() => {
     if (isMobile) {
-      navigate('/my-page');
+      navigate('/my-page', { replace: true });
     }
   }, [navigate]);
 

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { getUserInfo } from '@/api/users/user';
+import ensureHttps from '@/hooks/ensureHttps';
 
 const MyPage = () => {
   const navigate = useNavigate();
@@ -70,7 +71,7 @@ const MyPage = () => {
           ) : (
             <>
               <Image
-                src={userInfo?.profileImage || ''}
+                src={ensureHttps(userInfo?.profileImage || '')}
                 alt='profile'
                 className='w-[128px] h-[128px] rounded-[40px]'
                 onClick={() => {

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -17,7 +17,7 @@ const MyPage = () => {
 
   useEffect(() => {
     if (!isMobile) {
-      navigate('/my-page/profile-edit');
+      navigate('/my-page/profile-edit', { replace: true });
     }
   }, [navigate]);
 
@@ -75,7 +75,7 @@ const MyPage = () => {
                 alt='profile'
                 className='w-[128px] h-[128px] rounded-[40px]'
                 onClick={() => {
-                  navigate('/my-page/profile-edit');
+                  navigate('/my-page/profile-edit', { replace: true });
                 }}
               />
               <div className='flex flex-col justify-center gap-4'>
@@ -91,7 +91,7 @@ const MyPage = () => {
           <Button
             className='text-15 text-stone font-medium text-left px-4 py-2 cursor-pointer'
             onClick={() => {
-              navigate('/my-page/category-management');
+              navigate('/my-page/category-management', { replace: true });
             }}
           >
             카테고리 / 태그 관리

--- a/src/pages/myPage/ProfileEdit.tsx
+++ b/src/pages/myPage/ProfileEdit.tsx
@@ -9,6 +9,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { deleteUserInfo, getUserInfo, updateUserNickname } from '@/api/users/user';
 import toast from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
+import ensureHttps from '@/hooks/ensureHttps';
 
 const ProfileEdit = () => {
   const [nickname, setNickname] = useState('');
@@ -108,7 +109,7 @@ const ProfileEdit = () => {
               <div className='w-[96px] h-[96px] rounded-[20px] bg-gray-200' />
             ) : (
               <Image
-                src={userInfo?.profileImage || ''}
+                src={ensureHttps(userInfo?.profileImage || '')}
                 alt='profile'
                 className='w-[96px] h-[96px] rounded-[20px]'
               />


### PR DESCRIPTION
## 📂 관련 이슈

- closes #99 

<br>

## 🔀 PR 개요

> Page에서 발생되는 여러 오류 수정

<br>

## 📝 작업 내용

- 카카오 프로필 이미지가 http -> https로 처리
- 검색 결과에서 쿼리 상관 없이 전체 결과 값이 나오는 오류 수정
- 마이 페이지에서 수정 Page로 이동 시 쿼리를 가지고 있다면 쿼리도 포함하여 이동 되도록 수정
- 마이페이지가 검색 히스토리에 쌓이 않도록 수정
- Search Result 페이지에서 마이 페이지에 들어가 카테고리/태그 수정 시 검색 결과가 다시 조회되도록 수정

<br>

## 📸 스크린샷

https://github.com/user-attachments/assets/b45b3e25-573e-4785-85ff-a15447749fdf

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [x] 테스트 코드 추가 또는 기존 테스트 통과

<br>
