### PR TITLE
[Fix] #108 Search Result 페이지에 태그 오류 수정

### DIFF
--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -202,7 +202,9 @@ const SearchResult = () => {
 
       const uniqueTags = [
         ...new Set(
-          searchResult.data.content.map((bookmark) => bookmark.categoryTagInfos[0].tags[0].tagName),
+          searchResult.data.content.flatMap((bookmark) =>
+            bookmark.categoryTagInfos[0].tags.map((tag) => tag.tagName),
+          ),
         ),
       ];
 

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -79,8 +79,8 @@ const MyPage = () => {
                   alt='profile'
                   className='w-full h-auto aspect-square rounded-[40px] object-cover'
                   onClick={() => {
-                  navigate('/my-page/profile-edit', { replace: true });
-                }}
+                    navigate('/my-page/profile-edit', { replace: true });
+                  }}
                 />
               </div>
               <div className='flex flex-col justify-center gap-4'>


### PR DESCRIPTION
## 📂 관련 이슈

- closes #108 

<br>

## 🔀 PR 개요

> Search Result 페이지에 태그 오류 수정

<br>

## 📝 작업 내용

- Search Result 페이지에 DropDown에 모든 태그 값이 보이도록 수정

<br>

## 📸 스크린샷
<img width="776" height="242" alt="image" src="https://github.com/user-attachments/assets/c2bf1ce5-97ca-4549-84ca-623c217156ff" />

<br>

## ✅ 변경 사항 체크리스트

- [x] 기능 동작 확인
- [x] 타입 에러 없음
- [x] 기존 기능에 영향 없음
- [ x] 테스트 코드 추가 또는 기존 테스트 통과
